### PR TITLE
Tests/ccs 97 billing

### DIFF
--- a/frontend/src/components/billing/PaymentMethodsPanel.tsx
+++ b/frontend/src/components/billing/PaymentMethodsPanel.tsx
@@ -66,7 +66,7 @@ export default function PaymentMethodsPanel() {
   // UI state
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
-  const [items, setItems] = React.useState<PM[]>([]);
+  const [paymentMethods, setPaymentMethods] = React.useState<PM[]>([]);
   const [showAddForm, setShowAddForm] = React.useState(false);
 
   const load = React.useCallback(async () => {
@@ -77,20 +77,20 @@ export default function PaymentMethodsPanel() {
       const raw = res?.payment_methods ?? [];
 
       // default first
-      const list = [...raw].sort(
+      const pmList = [...raw].sort(
         (a, b) => Number(b.is_default) - Number(a.is_default),
       );
 
-      setItems(list);
-      setShowAddForm(list.length === 0);
+      setPaymentMethods(pmList);
+      setShowAddForm(pmList.length === 0);
     } catch {
       setError("Konnte Zahlungsdaten nicht laden.");
       // If we can't load, keep the form visible only if we have nothing cached
-      setShowAddForm((prev) => (items.length === 0 ? true : prev));
+      setShowAddForm((prev) => (paymentMethods.length === 0 ? true : prev));
     } finally {
       setLoading(false);
     }
-  }, [items.length]);
+  }, [paymentMethods.length]);
 
   React.useEffect(() => {
     void load();
@@ -108,18 +108,18 @@ export default function PaymentMethodsPanel() {
       {loading && <div className="text-gray-500">Lade…</div>}
 
       {/* Error state */}
-      {!loading && items.length === 0 && error && (
+      {!loading && paymentMethods.length === 0 && error && (
         <div className="text-red-600 mb-4">{error}</div>
       )}
 
       {/* List saved payment methods if any */}
-      {!loading && items.length > 0 && (
+      {!loading && paymentMethods.length > 0 && (
         <div className="mb-6">
           <h3 className="font-semibold text-gray-700 mb-2">
             Gespeicherte Karten
           </h3>
           <ul className="space-y-2">
-            {items.map((pm) => (
+            {paymentMethods.map((pm) => (
               <li
                 key={pm.id}
                 className="flex items-center justify-between rounded-xl border border-gray-200 px-4 py-2"
@@ -156,18 +156,12 @@ export default function PaymentMethodsPanel() {
       {!loading && showAddForm && (
         <SaveCardForm
           title="Kredit- oder Debitkarte hinzufügen"
-          showSkip={items.length === 0} // hide “Später” if we already have a card
+          showSkip={false} // Don't show skip button in User Settings
           onSuccess={async () => {
             await load(); // refresh list
             setShowAddForm(false); // collapse form
           }}
-          onSkip={() => {
-            if (items.length === 0) {
-              window.location.replace("/dashboard");
-            } else {
-              setShowAddForm(false);
-            }
-          }}
+          onSkip={() => {}}
         />
       )}
     </div>

--- a/frontend/tests/components/billing/PaymentMethodsPanel.test.tsx
+++ b/frontend/tests/components/billing/PaymentMethodsPanel.test.tsx
@@ -1,0 +1,176 @@
+import React from "react";
+import { act, render, screen } from '@testing-library/react'
+import PaymentMethodsPanel from "../../../src/components/billing/PaymentMethodsPanel";
+import { describe, it, expect, vi } from 'vitest';
+import "@testing-library/jest-dom/vitest";
+import { server } from "../../testServer";
+import { http, HttpResponse } from "msw";
+
+const API_PAYMENT = `http://127.0.0.1:8000/api/payments/stripe`;
+
+vi.mock("../../../src/components/payments/SaveCardForm", () => {
+    return {
+        default: () => (
+            <div data-testid="mocked-form">
+                Mocked SaveCardForm
+            </div>
+        ),
+    };
+});
+
+describe("PaymentMethodsPanel", () => {
+    it("show add card panel if no payment option configured", async () => {
+        server.use(
+            http.get(`${API_PAYMENT}/payment-methods/`, () => {
+                return HttpResponse.json({
+                    payment_methods: []
+                }, {
+                    headers: {
+                        'Cache-Control': 'no-store', // wie vom DSP-Backend
+                    }, status: 200
+                });
+            })
+        )
+        render(<PaymentMethodsPanel />)
+
+        const putCardHereText = await screen.findByText("Hinterlege hier deine Karte.", { exact: false });
+        expect(putCardHereText).toBeInTheDocument();
+
+        const mockedSaveCardForm = await screen.findByText("Mocked SaveCardForm");
+        expect(mockedSaveCardForm).toBeInTheDocument();
+
+        const addNewCardButton = screen.queryByRole("button", { name: "Neue Karte hinzufügen" });
+        expect(addNewCardButton).not.toBeInTheDocument();
+    });
+
+    it("don't show add card panel if payment option already configured", async () => {
+        server.use(
+            http.get(`${API_PAYMENT}/payment-methods/`, () => {
+                return HttpResponse.json({
+                    payment_methods: [
+                        {
+                            id: "pm_1ABCDEF",
+                            brand: "visa",
+                            last4: "4242",
+                            exp_month: 12,
+                            exp_year: new Date().getFullYear() + 1, // immer in der Zukunft
+                            is_default: true,
+                        }
+                    ]
+                }, {
+                    headers: {
+                        'Cache-Control': 'no-store', // wie vom DSP-Backend
+                    }, status: 200
+                });
+            }))
+        render(<PaymentMethodsPanel />)
+
+        const savedCards = await screen.findByText(/Gespeicherte Karten/i)
+        expect(savedCards).toBeInTheDocument();
+
+        const addNewCardButton = screen.getByRole("button", { name: "Neue Karte hinzufügen" });
+        expect(addNewCardButton).toBeInTheDocument();
+
+        const mockedSaveCardForm = screen.queryByText("Mocked SaveCardForm");
+        expect(mockedSaveCardForm).not.toBeInTheDocument();
+    });
+
+    it("default payment method is always first in the list", async () => {
+        server.use(
+            http.get(`${API_PAYMENT}/payment-methods/`, () => {
+                return HttpResponse.json({
+                    payment_methods: [
+                        {
+                            id: "pm_2SECOND",
+                            brand: "mastercard",
+                            last4: "5555",
+                            exp_month: 11,
+                            exp_year: new Date().getFullYear() + 1,
+                            is_default: false
+                        },
+                        {
+                            id: "pm_1DEFAULT",
+                            brand: "visa",
+                            last4: "4242",
+                            exp_month: 12,
+                            exp_year: new Date().getFullYear() + 1,
+                            is_default: true
+                        }
+                    ]
+                }, {
+                    headers: {
+                        'Cache-Control': 'no-store', // wie vom DSP-Backend
+                    }, status: 200
+                });
+            })
+        );
+        render(<PaymentMethodsPanel />);
+
+        const savedCards = await screen.findByText(/Gespeicherte Karten/i)
+        expect(savedCards).toBeInTheDocument();
+
+        const cards = screen.getAllByRole('listitem');
+        expect(cards[0]).toHaveTextContent("4242");
+        expect(cards[0]).toHaveTextContent("Standard");
+        expect(cards[1]).toHaveTextContent("5555");
+        expect(cards[1]).not.toHaveTextContent("Standard");
+
+        const mockedSaveCardForm = screen.queryByText("Mocked SaveCardForm");
+        expect(mockedSaveCardForm).not.toBeInTheDocument();
+    });
+
+    it("button text of 'add card' changes with click", async () => {
+        server.use(
+            http.get(`${API_PAYMENT}/payment-methods/`, () => {
+                return HttpResponse.json({
+                    payment_methods: [
+                        {
+                            id: "pm_1DEFAULT",
+                            brand: "visa",
+                            last4: "4242",
+                            exp_month: 12,
+                            exp_year: new Date().getFullYear() + 1,
+                            is_default: true
+                        }
+                    ]
+                }, {
+                    headers: {
+                        'Cache-Control': 'no-store', // wie vom DSP-Backend
+                    }, status: 200
+                });
+            })
+        );
+        render(<PaymentMethodsPanel />);
+
+        // Karte hinterlegt:
+        //      -> Button zeigt "Neue Karte hinzufügen"
+        //      -> Kreditkarten-Eingabemaske unsichtbar
+
+        const addNewCardButton = await screen.findByRole("button", { name: "Neue Karte hinzufügen" });
+        expect(addNewCardButton).toBeInTheDocument();
+
+        let mockedSaveCardForm = screen.queryByText("Mocked SaveCardForm");
+        expect(mockedSaveCardForm).not.toBeInTheDocument();
+
+        act(() => {
+            addNewCardButton?.click()
+        })        
+        // Klick auf "Neue Karte hinzufügen":
+        //      -> Button-Text wird zu "Abbrechen"
+        //      -> Kreditkarten-Eingabemaske sichtbar
+
+        expect(addNewCardButton).toHaveTextContent("Abbrechen");
+        mockedSaveCardForm = screen.queryByText("Mocked SaveCardForm");
+        expect(mockedSaveCardForm).toBeInTheDocument();
+
+         act(() => {
+            addNewCardButton?.click()
+        })      
+        // Klick auf "Abbrechen" :
+        //      -> Button-Text wird wider zu "Neue Karte hinzufügen"
+        //      -> Kreditkarten-Eingabemaske wieder unsichtbar
+        expect(addNewCardButton).toHaveTextContent("Neue Karte hinzufügen");
+        mockedSaveCardForm = screen.queryByText("Mocked SaveCardForm");
+        expect(mockedSaveCardForm).not.toBeInTheDocument();
+    });
+});

--- a/frontend/tests/components/billing/PaymentMethodsPanel.test.tsx
+++ b/frontend/tests/components/billing/PaymentMethodsPanel.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { act, render, screen } from '@testing-library/react'
+import { act, render, screen } from "@testing-library/react";
 import PaymentMethodsPanel from "../../../src/components/billing/PaymentMethodsPanel";
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import { server } from "../../testServer";
 import { http, HttpResponse } from "msw";
@@ -9,168 +9,190 @@ import { http, HttpResponse } from "msw";
 const API_PAYMENT = `http://127.0.0.1:8000/api/payments/stripe`;
 
 vi.mock("../../../src/components/payments/SaveCardForm", () => {
-    return {
-        default: () => (
-            <div data-testid="mocked-form">
-                Mocked SaveCardForm
-            </div>
-        ),
-    };
+  return {
+    default: () => <div data-testid="mocked-form">Mocked SaveCardForm</div>,
+  };
 });
 
 describe("PaymentMethodsPanel", () => {
-    it("show add card panel if no payment option configured", async () => {
-        server.use(
-            http.get(`${API_PAYMENT}/payment-methods/`, () => {
-                return HttpResponse.json({
-                    payment_methods: []
-                }, {
-                    headers: {
-                        'Cache-Control': 'no-store', // wie vom DSP-Backend
-                    }, status: 200
-                });
-            })
-        )
-        render(<PaymentMethodsPanel />)
-
-        const putCardHereText = await screen.findByText("Hinterlege hier deine Karte.", { exact: false });
-        expect(putCardHereText).toBeInTheDocument();
-
-        const mockedSaveCardForm = await screen.findByText("Mocked SaveCardForm");
-        expect(mockedSaveCardForm).toBeInTheDocument();
-
-        const addNewCardButton = screen.queryByRole("button", { name: "Neue Karte hinzufügen" });
-        expect(addNewCardButton).not.toBeInTheDocument();
-    });
-
-    it("don't show add card panel if payment option already configured", async () => {
-        server.use(
-            http.get(`${API_PAYMENT}/payment-methods/`, () => {
-                return HttpResponse.json({
-                    payment_methods: [
-                        {
-                            id: "pm_1ABCDEF",
-                            brand: "visa",
-                            last4: "4242",
-                            exp_month: 12,
-                            exp_year: new Date().getFullYear() + 1, // immer in der Zukunft
-                            is_default: true,
-                        }
-                    ]
-                }, {
-                    headers: {
-                        'Cache-Control': 'no-store', // wie vom DSP-Backend
-                    }, status: 200
-                });
-            }))
-        render(<PaymentMethodsPanel />)
-
-        const savedCards = await screen.findByText(/Gespeicherte Karten/i)
-        expect(savedCards).toBeInTheDocument();
-
-        const addNewCardButton = screen.getByRole("button", { name: "Neue Karte hinzufügen" });
-        expect(addNewCardButton).toBeInTheDocument();
-
-        const mockedSaveCardForm = screen.queryByText("Mocked SaveCardForm");
-        expect(mockedSaveCardForm).not.toBeInTheDocument();
-    });
-
-    it("default payment method is always first in the list", async () => {
-        server.use(
-            http.get(`${API_PAYMENT}/payment-methods/`, () => {
-                return HttpResponse.json({
-                    payment_methods: [
-                        {
-                            id: "pm_2SECOND",
-                            brand: "mastercard",
-                            last4: "5555",
-                            exp_month: 11,
-                            exp_year: new Date().getFullYear() + 1,
-                            is_default: false
-                        },
-                        {
-                            id: "pm_1DEFAULT",
-                            brand: "visa",
-                            last4: "4242",
-                            exp_month: 12,
-                            exp_year: new Date().getFullYear() + 1,
-                            is_default: true
-                        }
-                    ]
-                }, {
-                    headers: {
-                        'Cache-Control': 'no-store', // wie vom DSP-Backend
-                    }, status: 200
-                });
-            })
+  it("show add card panel if no payment option configured", async () => {
+    server.use(
+      http.get(`${API_PAYMENT}/payment-methods/`, () => {
+        return HttpResponse.json(
+          {
+            payment_methods: [],
+          },
+          {
+            headers: {
+              "Cache-Control": "no-store", // wie vom DSP-Backend
+            },
+            status: 200,
+          },
         );
-        render(<PaymentMethodsPanel />);
+      }),
+    );
+    render(<PaymentMethodsPanel />);
 
-        const savedCards = await screen.findByText(/Gespeicherte Karten/i)
-        expect(savedCards).toBeInTheDocument();
+    const putCardHereText = await screen.findByText(
+      "Hinterlege hier deine Karte.",
+      { exact: false },
+    );
+    expect(putCardHereText).toBeInTheDocument();
 
-        const cards = screen.getAllByRole('listitem');
-        expect(cards[0]).toHaveTextContent("4242");
-        expect(cards[0]).toHaveTextContent("Standard");
-        expect(cards[1]).toHaveTextContent("5555");
-        expect(cards[1]).not.toHaveTextContent("Standard");
+    const mockedSaveCardForm = await screen.findByText("Mocked SaveCardForm");
+    expect(mockedSaveCardForm).toBeInTheDocument();
 
-        const mockedSaveCardForm = screen.queryByText("Mocked SaveCardForm");
-        expect(mockedSaveCardForm).not.toBeInTheDocument();
+    const addNewCardButton = screen.queryByRole("button", {
+      name: "Neue Karte hinzufügen",
     });
+    expect(addNewCardButton).not.toBeInTheDocument();
+  });
 
-    it("button text of 'add card' changes with click", async () => {
-        server.use(
-            http.get(`${API_PAYMENT}/payment-methods/`, () => {
-                return HttpResponse.json({
-                    payment_methods: [
-                        {
-                            id: "pm_1DEFAULT",
-                            brand: "visa",
-                            last4: "4242",
-                            exp_month: 12,
-                            exp_year: new Date().getFullYear() + 1,
-                            is_default: true
-                        }
-                    ]
-                }, {
-                    headers: {
-                        'Cache-Control': 'no-store', // wie vom DSP-Backend
-                    }, status: 200
-                });
-            })
+  it("don't show add card panel if payment option already configured", async () => {
+    server.use(
+      http.get(`${API_PAYMENT}/payment-methods/`, () => {
+        return HttpResponse.json(
+          {
+            payment_methods: [
+              {
+                id: "pm_1ABCDEF",
+                brand: "visa",
+                last4: "4242",
+                exp_month: 12,
+                exp_year: new Date().getFullYear() + 1, // immer in der Zukunft
+                is_default: true,
+              },
+            ],
+          },
+          {
+            headers: {
+              "Cache-Control": "no-store", // wie vom DSP-Backend
+            },
+            status: 200,
+          },
         );
-        render(<PaymentMethodsPanel />);
+      }),
+    );
+    render(<PaymentMethodsPanel />);
 
-        // Karte hinterlegt:
-        //      -> Button zeigt "Neue Karte hinzufügen"
-        //      -> Kreditkarten-Eingabemaske unsichtbar
+    const savedCards = await screen.findByText(/Gespeicherte Karten/i);
+    expect(savedCards).toBeInTheDocument();
 
-        const addNewCardButton = await screen.findByRole("button", { name: "Neue Karte hinzufügen" });
-        expect(addNewCardButton).toBeInTheDocument();
-
-        let mockedSaveCardForm = screen.queryByText("Mocked SaveCardForm");
-        expect(mockedSaveCardForm).not.toBeInTheDocument();
-
-        act(() => {
-            addNewCardButton?.click()
-        })        
-        // Klick auf "Neue Karte hinzufügen":
-        //      -> Button-Text wird zu "Abbrechen"
-        //      -> Kreditkarten-Eingabemaske sichtbar
-
-        expect(addNewCardButton).toHaveTextContent("Abbrechen");
-        mockedSaveCardForm = screen.queryByText("Mocked SaveCardForm");
-        expect(mockedSaveCardForm).toBeInTheDocument();
-
-         act(() => {
-            addNewCardButton?.click()
-        })      
-        // Klick auf "Abbrechen" :
-        //      -> Button-Text wird wider zu "Neue Karte hinzufügen"
-        //      -> Kreditkarten-Eingabemaske wieder unsichtbar
-        expect(addNewCardButton).toHaveTextContent("Neue Karte hinzufügen");
-        mockedSaveCardForm = screen.queryByText("Mocked SaveCardForm");
-        expect(mockedSaveCardForm).not.toBeInTheDocument();
+    const addNewCardButton = screen.getByRole("button", {
+      name: "Neue Karte hinzufügen",
     });
+    expect(addNewCardButton).toBeInTheDocument();
+
+    const mockedSaveCardForm = screen.queryByText("Mocked SaveCardForm");
+    expect(mockedSaveCardForm).not.toBeInTheDocument();
+  });
+
+  it("default payment method is always first in the list", async () => {
+    server.use(
+      http.get(`${API_PAYMENT}/payment-methods/`, () => {
+        return HttpResponse.json(
+          {
+            payment_methods: [
+              {
+                id: "pm_2SECOND",
+                brand: "mastercard",
+                last4: "5555",
+                exp_month: 11,
+                exp_year: new Date().getFullYear() + 1,
+                is_default: false,
+              },
+              {
+                id: "pm_1DEFAULT",
+                brand: "visa",
+                last4: "4242",
+                exp_month: 12,
+                exp_year: new Date().getFullYear() + 1,
+                is_default: true,
+              },
+            ],
+          },
+          {
+            headers: {
+              "Cache-Control": "no-store", // wie vom DSP-Backend
+            },
+            status: 200,
+          },
+        );
+      }),
+    );
+    render(<PaymentMethodsPanel />);
+
+    const savedCards = await screen.findByText(/Gespeicherte Karten/i);
+    expect(savedCards).toBeInTheDocument();
+
+    const cards = screen.getAllByRole("listitem");
+    expect(cards[0]).toHaveTextContent("4242");
+    expect(cards[0]).toHaveTextContent("Standard");
+    expect(cards[1]).toHaveTextContent("5555");
+    expect(cards[1]).not.toHaveTextContent("Standard");
+
+    const mockedSaveCardForm = screen.queryByText("Mocked SaveCardForm");
+    expect(mockedSaveCardForm).not.toBeInTheDocument();
+  });
+
+  it("button text of 'add card' changes with click", async () => {
+    server.use(
+      http.get(`${API_PAYMENT}/payment-methods/`, () => {
+        return HttpResponse.json(
+          {
+            payment_methods: [
+              {
+                id: "pm_1DEFAULT",
+                brand: "visa",
+                last4: "4242",
+                exp_month: 12,
+                exp_year: new Date().getFullYear() + 1,
+                is_default: true,
+              },
+            ],
+          },
+          {
+            headers: {
+              "Cache-Control": "no-store", // wie vom DSP-Backend
+            },
+            status: 200,
+          },
+        );
+      }),
+    );
+    render(<PaymentMethodsPanel />);
+
+    // Karte hinterlegt:
+    //      -> Button zeigt "Neue Karte hinzufügen"
+    //      -> Kreditkarten-Eingabemaske unsichtbar
+
+    const addNewCardButton = await screen.findByRole("button", {
+      name: "Neue Karte hinzufügen",
+    });
+    expect(addNewCardButton).toBeInTheDocument();
+
+    let mockedSaveCardForm = screen.queryByText("Mocked SaveCardForm");
+    expect(mockedSaveCardForm).not.toBeInTheDocument();
+
+    act(() => {
+      addNewCardButton?.click();
+    });
+    // Klick auf "Neue Karte hinzufügen":
+    //      -> Button-Text wird zu "Abbrechen"
+    //      -> Kreditkarten-Eingabemaske sichtbar
+
+    expect(addNewCardButton).toHaveTextContent("Abbrechen");
+    mockedSaveCardForm = screen.queryByText("Mocked SaveCardForm");
+    expect(mockedSaveCardForm).toBeInTheDocument();
+
+    act(() => {
+      addNewCardButton?.click();
+    });
+    // Klick auf "Abbrechen" :
+    //      -> Button-Text wird wider zu "Neue Karte hinzufügen"
+    //      -> Kreditkarten-Eingabemaske wieder unsichtbar
+    expect(addNewCardButton).toHaveTextContent("Neue Karte hinzufügen");
+    mockedSaveCardForm = screen.queryByText("Mocked SaveCardForm");
+    expect(mockedSaveCardForm).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Added tests for the PaymentMethodsPanel Component:
- show add card panel if no payment option configured
- don't show add card panel if payment option already configured
- default payment method is always first in the list
- button text of 'add card' changes with click

Also, renamed some variables and setter functions PaymentMethodsPanel.tsx for better readability
Also, configured the SaveCardForm within PaymentMethodsPanel to never display the skip button in User Settings as it doesn't make any sense there