### PR TITLE
Make the footer not sticky

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -132,7 +132,7 @@ const AppContent: React.FC = () => {
   }
 
   return (
-    <div className="h-screen flex flex-col">
+    <div className="min-h-screen flex flex-col">
       {/* --- Background and Notifications --- */}
       <DSPBackground />
       <Toaster position="bottom-right" richColors />
@@ -146,7 +146,7 @@ const AppContent: React.FC = () => {
       />
 
       {/* --- Main Content Area --- */}
-      <main className="flex-grow overflow-auto">
+      <main className="flex-grow">
         {isFullScreenPage ? (
           // Full-screen layout for landing page and subscriptions (no margins)
           <AnimatedRoutes isAdmin={isAdmin} />


### PR DESCRIPTION
This PR removes the sticky behavior of the footer and ensures it scrolls naturally with the page content. Previously, the footer remained fixed at the bottom of the screen even when scrolling, due to the use of h-screen and overflow-auto in the layout structure. These have been adjusted in **App.tsx** by replacing h-screen with min-h-screen and removing overflow-auto from the main content area. As a result, the page now extends naturally, and the footer appears only after the user scrolls to the end of the content, providing a smoother and more consistent layout experience.