### PR TITLE
Feature/ccs 130 cloze texts

### DIFF
--- a/frontend/src/components/ui_elements/cloze_exercise/ClozeBlank.tsx
+++ b/frontend/src/components/ui_elements/cloze_exercise/ClozeBlank.tsx
@@ -2,104 +2,105 @@ import { memo, useState } from "react";
 import { SolutionWord } from "./SolutionWordBank";
 
 export interface ClozeBlankProps {
-    id: string;
-    showSolutionWords: boolean;
+  id: string;
+  showSolutionWords: boolean;
 
-    // Drag&Drop-Modus
-    currentWord?: Pick<SolutionWord, "id" | "word"> | null;
-    onDropWord?: (wordId: string) => void;       // Drop aus Wordbank => in diese Lücke
-    onCtrlClear?: (wordId: string) => void;      // Ctrl/Cmd-Klick auf belegte Lücke => leeren
+  // Drag&Drop-Modus
+  currentWord?: Pick<SolutionWord, "id" | "word"> | null;
+  onDropWord?: (wordId: string) => void; // Drop aus Wordbank => in diese Lücke
+  onCtrlClear?: (wordId: string) => void; // Ctrl/Cmd-Klick auf belegte Lücke => leeren
 
-    // Eingabemodus
-    inputValue?: string;
-    onInputChange?: (value: string) => void;
+  // Eingabemodus
+  inputValue?: string;
+  onInputChange?: (value: string) => void;
 
-    dataTestId?: string;
+  dataTestId?: string;
 }
 
 const ClozeBlank = memo<ClozeBlankProps>(
-    ({
-        id,
-        showSolutionWords,
-        currentWord = null,
-        onDropWord,
-        onCtrlClear,
-        inputValue = "",
-        onInputChange,
-    }) => {
-        // Lokaler Hover-State (ersetzt den bisherigen parent-state für visuelle Hervorhebung)
-        const [hovered, setHovered] = useState(false);
+  ({
+    id,
+    showSolutionWords,
+    currentWord = null,
+    onDropWord,
+    onCtrlClear,
+    inputValue = "",
+    onInputChange,
+  }) => {
+    // Lokaler Hover-State (ersetzt den bisherigen parent-state für visuelle Hervorhebung)
+    const [hovered, setHovered] = useState(false);
 
-        // Hilfsfunktionen für DnD
-        const handleDragStart = (
-            e: React.DragEvent<HTMLDivElement>,
-            wordId: string
-        ) => {
-            e.dataTransfer.setData("wordId", wordId);
-        };
+    // Hilfsfunktionen für DnD
+    const handleDragStart = (
+      e: React.DragEvent<HTMLDivElement>,
+      wordId: string,
+    ) => {
+      e.dataTransfer.setData("wordId", wordId);
+    };
 
-        const handleDropEvent = (e: React.DragEvent<HTMLDivElement>) => {
-            e.preventDefault();
-            setHovered(false);
-            const wordId = e.dataTransfer.getData("wordId");
-            if (wordId && onDropWord) onDropWord(wordId);
-        };
+    const handleDropEvent = (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      setHovered(false);
+      const wordId = e.dataTransfer.getData("wordId");
+      if (wordId && onDropWord) onDropWord(wordId);
+    };
 
-        if (showSolutionWords) {
-            // --- Drag & Drop Modus ---
-            return (
-                <div
-                    key={id}
-                    data-testid={`blank-${id}`}
-                    onDragEnter={() => setHovered(true)}
-                    onDragLeave={() => setHovered(false)}
-                    onDragOver={(e) => e.preventDefault()}
-                    onDrop={handleDropEvent}
-                    onClick={(e) => {
-                        if ((e.ctrlKey || e.metaKey) && currentWord?.id && onCtrlClear) {
-                            e.preventDefault();
-                            onCtrlClear(currentWord.id);
-                        }
-                    }}
-                    className={`inline-flex items-center justify-center min-w-[60px] min-h-[2.4rem] border-b-2 border-gray-400 text-center transition-colors ${hovered ? "bg-dsp-orange_light/50" : ""
-                        }`}
-                >
-                    {currentWord && (
-                        <div
-                            draggable
-                            onDragStart={(e) => handleDragStart(e, currentWord.id)}
-                            className="px-2 py-1 bg-dsp-orange_light/50 border border-dsp-orange_medium/60 rounded-xl cursor-grab select-none text-base"
-                        >
-                            {currentWord.word}
-                        </div>
-                    )}
-                </div>
-            );
-        }
-
-        // --- Eingabe-Modus ---
-        return (
+    if (showSolutionWords) {
+      // --- Drag & Drop Modus ---
+      return (
+        <div
+          key={id}
+          data-testid={`blank-${id}`}
+          onDragEnter={() => setHovered(true)}
+          onDragLeave={() => setHovered(false)}
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={handleDropEvent}
+          onClick={(e) => {
+            if ((e.ctrlKey || e.metaKey) && currentWord?.id && onCtrlClear) {
+              e.preventDefault();
+              onCtrlClear(currentWord.id);
+            }
+          }}
+          className={`inline-flex items-center justify-center min-w-[60px] min-h-[2.4rem] border-b-2 border-gray-400 text-center transition-colors ${
+            hovered ? "bg-dsp-orange_light/50" : ""
+          }`}
+        >
+          {currentWord && (
             <div
-                key={id}
-                className="inline-flex items-center justify-center border-b-2 border-gray-400 text-center align-baseline px-0.5"
+              draggable
+              onDragStart={(e) => handleDragStart(e, currentWord.id)}
+              className="px-2 py-1 bg-dsp-orange_light/50 border border-dsp-orange_medium/60 rounded-xl cursor-grab select-none text-base"
             >
-                <input
-                    type="text"
-                    value={inputValue}
-                    onChange={(e) => {
-                        const value = e.currentTarget.value;
-                        if (onInputChange) onInputChange(value);
-                        // dynamische Breite wie bisher
-                        e.currentTarget.style.width = `${Math.max(6, value.length)}ch`;
-                    }}
-                    style={{
-                        width: `${Math.max(6, inputValue?.length ?? 0)}ch`,
-                    }}
-                    className="text-center bg-transparent focus:outline-none text-gray-700 placeholder-gray-300 transition-[width] duration-150 ease-in-out"
-                />
+              {currentWord.word}
             </div>
-        );
+          )}
+        </div>
+      );
     }
+
+    // --- Eingabe-Modus ---
+    return (
+      <div
+        key={id}
+        className="inline-flex items-center justify-center border-b-2 border-gray-400 text-center align-baseline px-0.5"
+      >
+        <input
+          type="text"
+          value={inputValue}
+          onChange={(e) => {
+            const value = e.currentTarget.value;
+            if (onInputChange) onInputChange(value);
+            // dynamische Breite wie bisher
+            e.currentTarget.style.width = `${Math.max(6, value.length)}ch`;
+          }}
+          style={{
+            width: `${Math.max(6, inputValue?.length ?? 0)}ch`,
+          }}
+          className="text-center bg-transparent focus:outline-none text-gray-700 placeholder-gray-300 transition-[width] duration-150 ease-in-out"
+        />
+      </div>
+    );
+  },
 );
 
 ClozeBlank.displayName = "ClozeBlank";

--- a/frontend/src/components/ui_elements/cloze_exercise/ClozeBlank.tsx
+++ b/frontend/src/components/ui_elements/cloze_exercise/ClozeBlank.tsx
@@ -1,0 +1,106 @@
+import { memo, useState } from "react";
+import { SolutionWord } from "./SolutionWordBank";
+
+export interface ClozeBlankProps {
+    id: string;
+    showSolutionWords: boolean;
+
+    // Drag&Drop-Modus
+    currentWord?: Pick<SolutionWord, "id" | "word"> | null;
+    onDropWord?: (wordId: string) => void;       // Drop aus Wordbank => in diese Lücke
+    onCtrlClear?: (wordId: string) => void;      // Ctrl/Cmd-Klick auf belegte Lücke => leeren
+
+    // Eingabemodus
+    inputValue?: string;
+    onInputChange?: (value: string) => void;
+
+    dataTestId?: string;
+}
+
+const ClozeBlank = memo<ClozeBlankProps>(
+    ({
+        id,
+        showSolutionWords,
+        currentWord = null,
+        onDropWord,
+        onCtrlClear,
+        inputValue = "",
+        onInputChange,
+    }) => {
+        // Lokaler Hover-State (ersetzt den bisherigen parent-state für visuelle Hervorhebung)
+        const [hovered, setHovered] = useState(false);
+
+        // Hilfsfunktionen für DnD
+        const handleDragStart = (
+            e: React.DragEvent<HTMLDivElement>,
+            wordId: string
+        ) => {
+            e.dataTransfer.setData("wordId", wordId);
+        };
+
+        const handleDropEvent = (e: React.DragEvent<HTMLDivElement>) => {
+            e.preventDefault();
+            setHovered(false);
+            const wordId = e.dataTransfer.getData("wordId");
+            if (wordId && onDropWord) onDropWord(wordId);
+        };
+
+        if (showSolutionWords) {
+            // --- Drag & Drop Modus ---
+            return (
+                <div
+                    key={id}
+                    data-testid={`blank-${id}`}
+                    onDragEnter={() => setHovered(true)}
+                    onDragLeave={() => setHovered(false)}
+                    onDragOver={(e) => e.preventDefault()}
+                    onDrop={handleDropEvent}
+                    onClick={(e) => {
+                        if ((e.ctrlKey || e.metaKey) && currentWord?.id && onCtrlClear) {
+                            e.preventDefault();
+                            onCtrlClear(currentWord.id);
+                        }
+                    }}
+                    className={`inline-flex items-center justify-center min-w-[60px] min-h-[2.4rem] border-b-2 border-gray-400 text-center transition-colors ${hovered ? "bg-dsp-orange_light/50" : ""
+                        }`}
+                >
+                    {currentWord && (
+                        <div
+                            draggable
+                            onDragStart={(e) => handleDragStart(e, currentWord.id)}
+                            className="px-2 py-1 bg-dsp-orange_light/50 border border-dsp-orange_medium/60 rounded-xl cursor-grab select-none text-base"
+                        >
+                            {currentWord.word}
+                        </div>
+                    )}
+                </div>
+            );
+        }
+
+        // --- Eingabe-Modus ---
+        return (
+            <div
+                key={id}
+                className="inline-flex items-center justify-center border-b-2 border-gray-400 text-center align-baseline px-0.5"
+            >
+                <input
+                    type="text"
+                    value={inputValue}
+                    onChange={(e) => {
+                        const value = e.currentTarget.value;
+                        if (onInputChange) onInputChange(value);
+                        // dynamische Breite wie bisher
+                        e.currentTarget.style.width = `${Math.max(6, value.length)}ch`;
+                    }}
+                    style={{
+                        width: `${Math.max(6, inputValue?.length ?? 0)}ch`,
+                    }}
+                    className="text-center bg-transparent focus:outline-none text-gray-700 placeholder-gray-300 transition-[width] duration-150 ease-in-out"
+                />
+            </div>
+        );
+    }
+);
+
+ClozeBlank.displayName = "ClozeBlank";
+export default ClozeBlank;

--- a/frontend/src/components/ui_elements/cloze_exercise/ClozeExercise.tsx
+++ b/frontend/src/components/ui_elements/cloze_exercise/ClozeExercise.tsx
@@ -5,238 +5,257 @@ import ClozeBlank from "./ClozeBlank";
 import ClozeHeader from "./ClozeHeader";
 import ClozeSubmitButton from "./ClozeSubmitButton";
 
-
 export interface ClozeExerciseProps {
-    title?: string;
-    clozeText: ClozeTextPart[];
+  title?: string;
+  clozeText: ClozeTextPart[];
 
-    // determines whether the correct answers are displayed
-    // above the text and drag'n'droppable into the clozes.
-    showSolutionWords: boolean;
+  // determines whether the correct answers are displayed
+  // above the text and drag'n'droppable into the clozes.
+  showSolutionWords: boolean;
 
-    // add wrong answers to the drag'n'droppable
-    // solution words to increase difficulty
-    wrongSolutionWords?: string[];
+  // add wrong answers to the drag'n'droppable
+  // solution words to increase difficulty
+  wrongSolutionWords?: string[];
 
-    onSubmit: () => void;
+  onSubmit: () => void;
 }
 
 export interface ClozeResult {
-    answers: Record<string, string>;
-    correct: boolean;
-    details: Record<string, { isCorrect: boolean; correctAnswers: string[] }>;
+  answers: Record<string, string>;
+  correct: boolean;
+  details: Record<string, { isCorrect: boolean; correctAnswers: string[] }>;
 }
 
 export type ClozeTextPart =
-    | { type: "text"; content: string }
-    | { type: "blank"; correct: string[] };
+  | { type: "text"; content: string }
+  | { type: "blank"; correct: string[] };
 
 type ClozeBlank = { type: "blank"; id: string; correct: string[] };
 
 const normalize = (s: string) => s.trim().toLowerCase();
 const isCorrectAnswer = (user: string, correct: string[]) =>
-    correct.some(c => normalize(c) === normalize(user));
+  correct.some((c) => normalize(c) === normalize(user));
 
 export const ClozeExercise = memo<ClozeExerciseProps>(
-    ({ title = "Fülle die Lücken aus:", clozeText, showSolutionWords = false, wrongSolutionWords = [], onSubmit }) => {
+  ({
+    title = "Fülle die Lücken aus:",
+    clozeText,
+    showSolutionWords = false,
+    wrongSolutionWords = [],
+    onSubmit,
+  }) => {
+    const clozeTextWithIds = useMemo(() => {
+      return clozeText.map((part, index) => {
+        if (part.type === "blank") {
+          return { ...part, id: `${index}` };
+        }
+        return part;
+      });
+    }, [clozeText]);
 
-        const clozeTextWithIds = useMemo(() => {
-            return clozeText.map((part, index) => {
-                if (part.type === "blank") {
-                    return { ...part, id: `${index}` };
-                }
-                return part;
-            });
-        }, [clozeText]);
+    const blanks = useMemo(
+      () => clozeTextWithIds.filter((t): t is ClozeBlank => t.type === "blank"),
+      [clozeTextWithIds],
+    );
 
-        const blanks = useMemo(
-            () => clozeTextWithIds.filter((t): t is ClozeBlank => t.type === "blank"),
-            [clozeTextWithIds]
-        );
+    const [answers, setAnswers] = useState<Record<string, string>>({});
+    const [solutionWords, setSolutionWords] = useState<SolutionWord[]>(() => {
+      if (!showSolutionWords) return [];
 
-        const [answers, setAnswers] = useState<Record<string, string>>({});
-        const [solutionWords, setSolutionWords] = useState<SolutionWord[]>(() => {
-            if (!showSolutionWords)
-                return [];
+      const initialWords = [
+        ...clozeTextWithIds
+          .filter((p) => p.type === "blank")
+          .map((p) => p.correct[0]),
+        ...wrongSolutionWords,
+      ].sort();
 
-            const initialWords = [
-                ...clozeTextWithIds.filter(p => p.type === "blank").map(p => p.correct[0]),
-                ...wrongSolutionWords,
-            ].sort();
+      return initialWords.map((word, i) => ({
+        id: i.toString(),
+        word,
+        available: true,
+      }));
+    });
 
-            return initialWords.map((word, i) => ({ id: i.toString(), word, available: true }));
-        });
+    // Hilfsfunktion: gibt den Text zurück, den wir prüfen wollen (immer ein String)
+    const getUserAnswerText = (blankId: string) => {
+      const val = answers[blankId];
+      if (val == null) return ""; // keine Antwort
 
-        // Hilfsfunktion: gibt den Text zurück, den wir prüfen wollen (immer ein String)
-        const getUserAnswerText = (blankId: string) => {
-            const val = answers[blankId];
-            if (val == null) return ""; // keine Antwort
+      // Wenn der Drag & Drop-Modus aktiv ist, ist answers[blankId] eine word-id -> löse sie auf
+      if (showSolutionWords) {
+        const word = solutionWords.find((w) => w.id === val);
+        return word?.word ?? "";
+      }
 
-            // Wenn der Drag & Drop-Modus aktiv ist, ist answers[blankId] eine word-id -> löse sie auf
-            if (showSolutionWords) {
-                const word = solutionWords.find(w => w.id === val);
-                return word?.word ?? "";
-            }
+      // Sonst: Eingabemodus -> val ist bereits der Text
+      return String(val);
+    };
 
-            // Sonst: Eingabemodus -> val ist bereits der Text
-            return String(val);
-        };
+    const allFilled = blanks.every(
+      (b) => getUserAnswerText(b.id).trim().length > 0,
+    );
+    const allCorrect = blanks.every((b) =>
+      isCorrectAnswer(getUserAnswerText(b.id), b.correct),
+    );
 
-        const allFilled = blanks.every(b => getUserAnswerText(b.id).trim().length > 0);
-        const allCorrect = blanks.every(b => isCorrectAnswer(getUserAnswerText(b.id), b.correct));
+    const handleDropIntoBlank = (blankId: string, wordId: string) => {
+      const droppedWord = solutionWords.find((w) => w.id === wordId);
+      if (!droppedWord) return;
 
-        const handleDropIntoBlank = (blankId: string, wordId: string) => {
-            const droppedWord = solutionWords.find(w => w.id === wordId);
-            if (!droppedWord) return;
+      // Finde, ob das Wort bereits woanders genutzt wurde
+      const previousBlankId = Object.entries(answers).find(
+        ([, id]) => id === wordId,
+      )?.[0];
 
-            // Finde, ob das Wort bereits woanders genutzt wurde
-            const previousBlankId = Object.entries(answers).find(
-                ([, id]) => id === wordId
-            )?.[0];
+      setAnswers((prev) => {
+        const updated = { ...prev };
 
-            setAnswers(prev => {
-                const updated = { ...prev };
-
-                // Wenn das Wort schon irgendwo war → alte Lücke leeren
-                if (previousBlankId) {
-                    delete updated[previousBlankId];
-                }
-
-                // Wenn Ziel-Lücke schon ein anderes Wort hat → das andere Wort freigeben
-                const replacedWordId = prev[blankId];
-                if (replacedWordId && replacedWordId !== wordId) {
-                    setSolutionWords(prevWords =>
-                        prevWords.map(w =>
-                            w.id === replacedWordId ? { ...w, available: true } : w
-                        )
-                    );
-                }
-
-                // Neues Wort in Ziel-Lücke setzen
-                updated[blankId] = wordId;
-                return updated;
-            });
-
-            // Das gezogene Wort als „nicht verfügbar“ markieren
-            setSolutionWords(prev =>
-                prev.map(w =>
-                    w.id === wordId ? { ...w, available: false } : w
-                )
-            );
-        };
-
-        const handleReturnToBank = (wordId: string) => {
-            // Blank finden, in dem dieses Wort aktuell liegt
-            const blankId = Object.keys(answers).find(key => answers[key] === wordId);
-            if (!blankId)
-                return;
-
-            // Wort wieder aktivieren
-            setSolutionWords(prev =>
-                prev.map(w => (w.id === wordId ? { ...w, available: true } : w))
-            );
-
-            // Blank leeren
-            setAnswers(prev => {
-                const copy = { ...prev };
-                delete copy[blankId];
-                return copy;
-            });
+        // Wenn das Wort schon irgendwo war → alte Lücke leeren
+        if (previousBlankId) {
+          delete updated[previousBlankId];
         }
 
-        const handleQuickPlace = (wordId: string) => {
-            // erste freie Lücke finden
-            const firstEmptyBlank = blanks.find((blank) => !answers[blank.id]);
-            if (!firstEmptyBlank) return;
+        // Wenn Ziel-Lücke schon ein anderes Wort hat → das andere Wort freigeben
+        const replacedWordId = prev[blankId];
+        if (replacedWordId && replacedWordId !== wordId) {
+          setSolutionWords((prevWords) =>
+            prevWords.map((w) =>
+              w.id === replacedWordId ? { ...w, available: true } : w,
+            ),
+          );
+        }
 
-            handleDropIntoBlank(firstEmptyBlank.id, wordId);
-        };
+        // Neues Wort in Ziel-Lücke setzen
+        updated[blankId] = wordId;
+        return updated;
+      });
 
-        const clearBlank = (blankId: string) => {
-            const wordId = answers[blankId];
-            if (!wordId) return;
+      // Das gezogene Wort als „nicht verfügbar“ markieren
+      setSolutionWords((prev) =>
+        prev.map((w) => (w.id === wordId ? { ...w, available: false } : w)),
+      );
+    };
 
-            setSolutionWords((prev) =>
-                prev.map((w) => (w.id === wordId ? { ...w, available: true } : w))
+    const handleReturnToBank = (wordId: string) => {
+      // Blank finden, in dem dieses Wort aktuell liegt
+      const blankId = Object.keys(answers).find(
+        (key) => answers[key] === wordId,
+      );
+      if (!blankId) return;
+
+      // Wort wieder aktivieren
+      setSolutionWords((prev) =>
+        prev.map((w) => (w.id === wordId ? { ...w, available: true } : w)),
+      );
+
+      // Blank leeren
+      setAnswers((prev) => {
+        const copy = { ...prev };
+        delete copy[blankId];
+        return copy;
+      });
+    };
+
+    const handleQuickPlace = (wordId: string) => {
+      // erste freie Lücke finden
+      const firstEmptyBlank = blanks.find((blank) => !answers[blank.id]);
+      if (!firstEmptyBlank) return;
+
+      handleDropIntoBlank(firstEmptyBlank.id, wordId);
+    };
+
+    const clearBlank = (blankId: string) => {
+      const wordId = answers[blankId];
+      if (!wordId) return;
+
+      setSolutionWords((prev) =>
+        prev.map((w) => (w.id === wordId ? { ...w, available: true } : w)),
+      );
+
+      setAnswers((prev) => {
+        const updated = { ...prev };
+        delete updated[blankId];
+        return updated;
+      });
+    };
+
+    const checkResults = () => {
+      if (allCorrect) onSubmit();
+    };
+
+    return (
+      <SubBackground>
+        {/* --- Header --- */}
+        <ClozeHeader title={title} />
+
+        {/* --- Lösungsauswahl (nur wenn Lösungswörter sichtbar) --- */}
+        {showSolutionWords && (
+          <SolutionWordBank
+            words={solutionWords}
+            onReturnToBank={handleReturnToBank}
+            onQuickPlace={handleQuickPlace}
+          />
+        )}
+
+        {/* --- Lückentext --- */}
+        <div className="flex flex-wrap gap-1 mb-4 text-lg leading-[1.6]">
+          {clozeTextWithIds.map((part, i) => {
+            if (part.type === "text") {
+              return (
+                <span key={i} className="text-gray-600 mt-1">
+                  {part.content}
+                </span>
+              );
+            }
+
+            // --- Drag & Drop Modus ---
+            if (showSolutionWords) {
+              const currentAnswerId = answers[part.id];
+              const currentWord =
+                solutionWords.find((w) => w.id === currentAnswerId) || null;
+
+              return (
+                <ClozeBlank
+                  key={part.id}
+                  id={part.id}
+                  showSolutionWords
+                  currentWord={
+                    currentWord
+                      ? { id: currentWord.id, word: currentWord.word }
+                      : null
+                  }
+                  onDropWord={(wordId) => handleDropIntoBlank(part.id, wordId)}
+                  onCtrlClear={() => clearBlank(part.id)}
+                />
+              );
+            }
+
+            // --- Eingabe-Modus ---
+            return (
+              <ClozeBlank
+                key={part.id}
+                id={part.id}
+                showSolutionWords={false}
+                inputValue={answers[part.id] ?? ""}
+                onInputChange={(value) =>
+                  setAnswers((prev) => ({ ...prev, [part.id]: value }))
+                }
+              />
             );
+          })}
+        </div>
 
-            setAnswers((prev) => {
-                const updated = { ...prev };
-                delete updated[blankId];
-                return updated;
-            });
-        };
-
-        const checkResults = () => {
-            if (allCorrect)
-                onSubmit();
-        };
-
-        return (
-            <SubBackground>
-                {/* --- Header --- */}
-                <ClozeHeader title={title} />
-
-                {/* --- Lösungsauswahl (nur wenn Lösungswörter sichtbar) --- */}
-                {showSolutionWords && (
-                    <SolutionWordBank
-                        words={solutionWords}
-                        onReturnToBank={handleReturnToBank}
-                        onQuickPlace={handleQuickPlace}
-                    />
-                )}
-
-                {/* --- Lückentext --- */}
-                <div className="flex flex-wrap gap-1 mb-4 text-lg leading-[1.6]">
-                    {clozeTextWithIds.map((part, i) => {
-                        if (part.type === "text") {
-                            return (
-                                <span key={i} className="text-gray-600 mt-1">
-                                    {part.content}
-                                </span>
-                            );
-                        }
-
-                        // --- Drag & Drop Modus ---
-                        if (showSolutionWords) {
-                            const currentAnswerId = answers[part.id];
-                            const currentWord = solutionWords.find((w) => w.id === currentAnswerId) || null;
-
-                            return (
-                                <ClozeBlank
-                                    key={part.id}
-                                    id={part.id}
-                                    showSolutionWords
-                                    currentWord={currentWord ? { id: currentWord.id, word: currentWord.word } : null}
-                                    onDropWord={(wordId) => handleDropIntoBlank(part.id, wordId)}
-                                    onCtrlClear={() => clearBlank(part.id)}
-                                />
-                            );
-                        }
-
-                        // --- Eingabe-Modus ---
-                        return (
-                            <ClozeBlank
-                                key={part.id}
-                                id={part.id}
-                                showSolutionWords={false}
-                                inputValue={answers[part.id] ?? ""}
-                                onInputChange={(value) =>
-                                    setAnswers((prev) => ({ ...prev, [part.id]: value }))
-                                }
-                            />
-                        );
-                    })}
-                </div>
-
-                {/* --- OK-Button --- }*/}
-                <ClozeSubmitButton label="Prüfen" disabled={!allFilled} onClick={checkResults} />
-            </SubBackground>
-        );
-    }
+        {/* --- OK-Button --- }*/}
+        <ClozeSubmitButton
+          label="Prüfen"
+          disabled={!allFilled}
+          onClick={checkResults}
+        />
+      </SubBackground>
+    );
+  },
 );
 
-
-ClozeExercise.displayName = "ClozeExercise"
+ClozeExercise.displayName = "ClozeExercise";
 
 export default ClozeExercise;

--- a/frontend/src/components/ui_elements/cloze_exercise/ClozeExercise.tsx
+++ b/frontend/src/components/ui_elements/cloze_exercise/ClozeExercise.tsx
@@ -1,10 +1,9 @@
 import { SubBackground } from "@/components/layouts";
-import { memo, useMemo, useState } from "react";
+import { memo, useMemo, useState, useEffect } from "react";
 import SolutionWordBank, { SolutionWord } from "./SolutionWordBank";
 import ClozeBlank from "./ClozeBlank";
 import ClozeHeader from "./ClozeHeader";
 import ClozeSubmitButton from "./ClozeSubmitButton";
-
 
 export interface ClozeExerciseProps {
     title?: string;
@@ -35,11 +34,16 @@ type ClozeBlank = { type: "blank"; id: string; correct: string[] };
 
 const normalize = (s: string) => s.trim().toLowerCase();
 const isCorrectAnswer = (user: string, correct: string[]) =>
-    correct.some(c => normalize(c) === normalize(user));
+    correct.some((c) => normalize(c) === normalize(user));
 
 export const ClozeExercise = memo<ClozeExerciseProps>(
-    ({ title = "Fülle die Lücken aus:", clozeText, showSolutionWords = false, wrongSolutionWords = [], onSubmit }) => {
-
+    ({
+        title = "Fülle die Lücken aus:",
+        clozeText,
+        showSolutionWords = false,
+        wrongSolutionWords = [],
+        onSubmit,
+    }) => {
         const clozeTextWithIds = useMemo(() => {
             return clozeText.map((part, index) => {
                 if (part.type === "blank") {
@@ -67,6 +71,18 @@ export const ClozeExercise = memo<ClozeExerciseProps>(
             return initialWords.map((word, i) => ({ id: i.toString(), word, available: true }));
         });
 
+        // --- Feedback-State unter dem Button ---
+        const [feedback, setFeedback] = useState<{
+            type: "success" | "error" | null;
+            message: string;
+        }>({ type: null, message: "" });
+
+        // Feedback zurücksetzen, sobald der/die Nutzer:in weiterarbeitet
+        useEffect(() => {
+            if (feedback.type) setFeedback({ type: null, message: "" });
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, [answers]);
+
         // Hilfsfunktion: gibt den Text zurück, den wir prüfen wollen (immer ein String)
         const getUserAnswerText = (blankId: string) => {
             const val = answers[blankId];
@@ -83,7 +99,6 @@ export const ClozeExercise = memo<ClozeExerciseProps>(
         };
 
         const allFilled = blanks.every(b => getUserAnswerText(b.id).trim().length > 0);
-        const allCorrect = blanks.every(b => isCorrectAnswer(getUserAnswerText(b.id), b.correct));
 
         const handleDropIntoBlank = (blankId: string, wordId: string) => {
             const droppedWord = solutionWords.find(w => w.id === wordId);
@@ -127,7 +142,9 @@ export const ClozeExercise = memo<ClozeExerciseProps>(
 
         const handleReturnToBank = (wordId: string) => {
             // Blank finden, in dem dieses Wort aktuell liegt
-            const blankId = Object.keys(answers).find(key => answers[key] === wordId);
+            const blankId = Object.keys(answers).find(
+                (key) => answers[key] === wordId
+            );
             if (!blankId)
                 return;
 
@@ -142,7 +159,7 @@ export const ClozeExercise = memo<ClozeExerciseProps>(
                 delete copy[blankId];
                 return copy;
             });
-        }
+        };
 
         const handleQuickPlace = (wordId: string) => {
             // erste freie Lücke finden
@@ -168,8 +185,25 @@ export const ClozeExercise = memo<ClozeExerciseProps>(
         };
 
         const checkResults = () => {
-            if (allCorrect)
+            // Zähle korrekte Antworten
+            const correctCount = blanks.reduce((acc, b) => {
+                const user = getUserAnswerText(b.id);
+                return acc + (isCorrectAnswer(user, b.correct) ? 1 : 0);
+            }, 0);
+            const total = blanks.length;
+
+            if (correctCount === total) {
+                setFeedback({
+                    type: "success",
+                    message: "🎉 Alles richtig! Super gemacht!",
+                });
                 onSubmit();
+            } else {
+                setFeedback({
+                    type: "error",
+                    message: `Noch nicht ganz: ${correctCount} von ${total} richtig. Schau dir die Lücken nochmal an und probier’s erneut.`,
+                });
+            }
         };
 
         return (
@@ -207,7 +241,11 @@ export const ClozeExercise = memo<ClozeExerciseProps>(
                                     key={part.id}
                                     id={part.id}
                                     showSolutionWords
-                                    currentWord={currentWord ? { id: currentWord.id, word: currentWord.word } : null}
+                                    currentWord={
+                                        currentWord
+                                            ? { id: currentWord.id, word: currentWord.word }
+                                            : null
+                                    }
                                     onDropWord={(wordId) => handleDropIntoBlank(part.id, wordId)}
                                     onCtrlClear={() => clearBlank(part.id)}
                                 />
@@ -229,14 +267,32 @@ export const ClozeExercise = memo<ClozeExerciseProps>(
                     })}
                 </div>
 
-                {/* --- OK-Button --- }*/}
-                <ClozeSubmitButton label="Prüfen" disabled={!allFilled} onClick={checkResults} />
+                {/* --- OK-Button --- */}
+                <ClozeSubmitButton
+                    label="Prüfen"
+                    disabled={!allFilled}
+                    onClick={checkResults}
+                />
+
+                {/* --- Feedback unter dem Button --- */}
+                {feedback.type && (
+                    <div
+                        className={[
+                            "mt-3 rounded-md border px-3 py-2 text-sm",
+                            feedback.type === "success"
+                                ? "border-green-200 bg-green-50 text-green-700"
+                                : "border-red-200 bg-red-50 text-red-700",
+                        ].join(" ")}
+                        role="status"
+                        aria-live="polite"
+                    >
+                        {feedback.message}
+                    </div>
+                )}
             </SubBackground>
         );
     }
 );
 
-
-ClozeExercise.displayName = "ClozeExercise"
-
+ClozeExercise.displayName = "ClozeExercise";
 export default ClozeExercise;

--- a/frontend/src/components/ui_elements/cloze_exercise/ClozeExercise.tsx
+++ b/frontend/src/components/ui_elements/cloze_exercise/ClozeExercise.tsx
@@ -6,297 +6,297 @@ import ClozeHeader from "./ClozeHeader";
 import ClozeSubmitButton from "./ClozeSubmitButton";
 
 export interface ClozeExerciseProps {
-    title?: string;
-    clozeText: ClozeTextPart[];
+  title?: string;
+  clozeText: ClozeTextPart[];
 
-    // determines whether the correct answers are displayed
-    // above the text and drag'n'droppable into the clozes.
-    showSolutionWords: boolean;
+  // determines whether the correct answers are displayed
+  // above the text and drag'n'droppable into the clozes.
+  showSolutionWords: boolean;
 
-    // add wrong answers to the drag'n'droppable
-    // solution words to increase difficulty
-    wrongSolutionWords?: string[];
+  // add wrong answers to the drag'n'droppable
+  // solution words to increase difficulty
+  wrongSolutionWords?: string[];
 
-    onSubmit: () => void;
+  onSubmit: () => void;
 }
 
 export interface ClozeResult {
-    answers: Record<string, string>;
-    correct: boolean;
-    details: Record<string, { isCorrect: boolean; correctAnswers: string[] }>;
+  answers: Record<string, string>;
+  correct: boolean;
+  details: Record<string, { isCorrect: boolean; correctAnswers: string[] }>;
 }
 
 export type ClozeTextPart =
-    | { type: "text"; content: string }
-    | { type: "blank"; correct: string[] };
+  | { type: "text"; content: string }
+  | { type: "blank"; correct: string[] };
 
 type ClozeBlank = { type: "blank"; id: string; correct: string[] };
 
 const normalize = (s: string) => s.trim().toLowerCase();
 const isCorrectAnswer = (user: string, correct: string[]) =>
-    correct.some((c) => normalize(c) === normalize(user));
+  correct.some((c) => normalize(c) === normalize(user));
 
 export const ClozeExercise = memo<ClozeExerciseProps>(
-    ({
-        title = "Fülle die Lücken aus:",
-        clozeText,
-        showSolutionWords = false,
-        wrongSolutionWords = [],
-        onSubmit,
-    }) => {
-        const clozeTextWithIds = useMemo(() => {
-            return clozeText.map((part, index) => {
-                if (part.type === "blank") {
-                    return { ...part, id: `${index}` };
-                }
-                return part;
-            });
-        }, [clozeText]);
+  ({
+    title = "Fülle die Lücken aus:",
+    clozeText,
+    showSolutionWords = false,
+    wrongSolutionWords = [],
+    onSubmit,
+  }) => {
+    const clozeTextWithIds = useMemo(() => {
+      return clozeText.map((part, index) => {
+        if (part.type === "blank") {
+          return { ...part, id: `${index}` };
+        }
+        return part;
+      });
+    }, [clozeText]);
 
-        const blanks = useMemo(
-            () => clozeTextWithIds.filter((t): t is ClozeBlank => t.type === "blank"),
-            [clozeTextWithIds]
-        );
+    const blanks = useMemo(
+      () => clozeTextWithIds.filter((t): t is ClozeBlank => t.type === "blank"),
+      [clozeTextWithIds],
+    );
 
-        const [answers, setAnswers] = useState<Record<string, string>>({});
-        const [solutionWords, setSolutionWords] = useState<SolutionWord[]>(() => {
-            if (!showSolutionWords) return [];
+    const [answers, setAnswers] = useState<Record<string, string>>({});
+    const [solutionWords, setSolutionWords] = useState<SolutionWord[]>(() => {
+      if (!showSolutionWords) return [];
 
-            const initialWords = [
-                ...clozeTextWithIds
-                    .filter((p) => p.type === "blank")
-                    .map((p) => p.correct[0]),
-                ...wrongSolutionWords,
-            ].sort();
+      const initialWords = [
+        ...clozeTextWithIds
+          .filter((p) => p.type === "blank")
+          .map((p) => p.correct[0]),
+        ...wrongSolutionWords,
+      ].sort();
 
-            return initialWords.map((word, i) => ({
-                id: i.toString(),
-                word,
-                available: true,
-            }));
+      return initialWords.map((word, i) => ({
+        id: i.toString(),
+        word,
+        available: true,
+      }));
+    });
+
+    // --- Feedback-State unter dem Button ---
+    const [feedback, setFeedback] = useState<{
+      type: "success" | "error" | null;
+      message: string;
+    }>({ type: null, message: "" });
+
+    // Feedback zurücksetzen, sobald der/die Nutzer:in weiterarbeitet
+    useEffect(() => {
+      if (feedback.type) setFeedback({ type: null, message: "" });
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [answers]);
+
+    // Hilfsfunktion: gibt den Text zurück, den wir prüfen wollen (immer ein String)
+    const getUserAnswerText = (blankId: string) => {
+      const val = answers[blankId];
+      if (val == null) return ""; // keine Antwort
+
+      // Wenn der Drag & Drop-Modus aktiv ist, ist answers[blankId] eine word-id -> löse sie auf
+      if (showSolutionWords) {
+        const word = solutionWords.find((w) => w.id === val);
+        return word?.word ?? "";
+      }
+
+      // Sonst: Eingabemodus -> val ist bereits der Text
+      return String(val);
+    };
+
+    const allFilled = blanks.every(
+      (b) => getUserAnswerText(b.id).trim().length > 0,
+    );
+
+    const handleDropIntoBlank = (blankId: string, wordId: string) => {
+      const droppedWord = solutionWords.find((w) => w.id === wordId);
+      if (!droppedWord) return;
+
+      // Finde, ob das Wort bereits woanders genutzt wurde
+      const previousBlankId = Object.entries(answers).find(
+        ([, id]) => id === wordId,
+      )?.[0];
+
+      setAnswers((prev) => {
+        const updated = { ...prev };
+
+        // Wenn das Wort schon irgendwo war → alte Lücke leeren
+        if (previousBlankId) {
+          delete updated[previousBlankId];
+        }
+
+        // Wenn Ziel-Lücke schon ein anderes Wort hat → das andere Wort freigeben
+        const replacedWordId = prev[blankId];
+        if (replacedWordId && replacedWordId !== wordId) {
+          setSolutionWords((prevWords) =>
+            prevWords.map((w) =>
+              w.id === replacedWordId ? { ...w, available: true } : w,
+            ),
+          );
+        }
+
+        // Neues Wort in Ziel-Lücke setzen
+        updated[blankId] = wordId;
+        return updated;
+      });
+
+      // Das gezogene Wort als „nicht verfügbar“ markieren
+      setSolutionWords((prev) =>
+        prev.map((w) => (w.id === wordId ? { ...w, available: false } : w)),
+      );
+    };
+
+    const handleReturnToBank = (wordId: string) => {
+      // Blank finden, in dem dieses Wort aktuell liegt
+      const blankId = Object.keys(answers).find(
+        (key) => answers[key] === wordId,
+      );
+      if (!blankId) return;
+
+      // Wort wieder aktivieren
+      setSolutionWords((prev) =>
+        prev.map((w) => (w.id === wordId ? { ...w, available: true } : w)),
+      );
+
+      // Blank leeren
+      setAnswers((prev) => {
+        const copy = { ...prev };
+        delete copy[blankId];
+        return copy;
+      });
+    };
+
+    const handleQuickPlace = (wordId: string) => {
+      // erste freie Lücke finden
+      const firstEmptyBlank = blanks.find((blank) => !answers[blank.id]);
+      if (!firstEmptyBlank) return;
+
+      handleDropIntoBlank(firstEmptyBlank.id, wordId);
+    };
+
+    const clearBlank = (blankId: string) => {
+      const wordId = answers[blankId];
+      if (!wordId) return;
+
+      setSolutionWords((prev) =>
+        prev.map((w) => (w.id === wordId ? { ...w, available: true } : w)),
+      );
+
+      setAnswers((prev) => {
+        const updated = { ...prev };
+        delete updated[blankId];
+        return updated;
+      });
+    };
+
+    const checkResults = () => {
+      // Zähle korrekte Antworten
+      const correctCount = blanks.reduce((acc, b) => {
+        const user = getUserAnswerText(b.id);
+        return acc + (isCorrectAnswer(user, b.correct) ? 1 : 0);
+      }, 0);
+      const total = blanks.length;
+
+      if (correctCount === total) {
+        setFeedback({
+          type: "success",
+          message: "🎉 Volltreffer! Alles korrekt. Super gemacht!",
         });
+        onSubmit();
+      } else {
+        setFeedback({
+          type: "error",
+          message: `Noch nicht ganz: ${correctCount} von ${total} richtig. Schau dir die Lücken nochmal an und probier’s erneut.`,
+        });
+      }
+    };
 
-        // --- Feedback-State unter dem Button ---
-        const [feedback, setFeedback] = useState<{
-            type: "success" | "error" | null;
-            message: string;
-        }>({ type: null, message: "" });
+    return (
+      <SubBackground>
+        {/* --- Header --- */}
+        <ClozeHeader title={title} />
 
-        // Feedback zurücksetzen, sobald der/die Nutzer:in weiterarbeitet
-        useEffect(() => {
-            if (feedback.type) setFeedback({ type: null, message: "" });
-            // eslint-disable-next-line react-hooks/exhaustive-deps
-        }, [answers]);
+        {/* --- Lösungsauswahl (nur wenn Lösungswörter sichtbar) --- */}
+        {showSolutionWords && (
+          <SolutionWordBank
+            words={solutionWords}
+            onReturnToBank={handleReturnToBank}
+            onQuickPlace={handleQuickPlace}
+          />
+        )}
 
-        // Hilfsfunktion: gibt den Text zurück, den wir prüfen wollen (immer ein String)
-        const getUserAnswerText = (blankId: string) => {
-            const val = answers[blankId];
-            if (val == null) return ""; // keine Antwort
+        {/* --- Lückentext --- */}
+        <div className="flex flex-wrap gap-1 mb-4 text-lg leading-[1.6]">
+          {clozeTextWithIds.map((part, i) => {
+            if (part.type === "text") {
+              return (
+                <span key={i} className="text-gray-600 mt-1">
+                  {part.content}
+                </span>
+              );
+            }
 
-            // Wenn der Drag & Drop-Modus aktiv ist, ist answers[blankId] eine word-id -> löse sie auf
+            // --- Drag & Drop Modus ---
             if (showSolutionWords) {
-                const word = solutionWords.find((w) => w.id === val);
-                return word?.word ?? "";
-            }
+              const currentAnswerId = answers[part.id];
+              const currentWord =
+                solutionWords.find((w) => w.id === currentAnswerId) || null;
 
-            // Sonst: Eingabemodus -> val ist bereits der Text
-            return String(val);
-        };
-
-        const allFilled = blanks.every(
-            (b) => getUserAnswerText(b.id).trim().length > 0
-        );
-
-        const handleDropIntoBlank = (blankId: string, wordId: string) => {
-            const droppedWord = solutionWords.find((w) => w.id === wordId);
-            if (!droppedWord) return;
-
-            // Finde, ob das Wort bereits woanders genutzt wurde
-            const previousBlankId = Object.entries(answers).find(
-                ([, id]) => id === wordId
-            )?.[0];
-
-            setAnswers((prev) => {
-                const updated = { ...prev };
-
-                // Wenn das Wort schon irgendwo war → alte Lücke leeren
-                if (previousBlankId) {
-                    delete updated[previousBlankId];
-                }
-
-                // Wenn Ziel-Lücke schon ein anderes Wort hat → das andere Wort freigeben
-                const replacedWordId = prev[blankId];
-                if (replacedWordId && replacedWordId !== wordId) {
-                    setSolutionWords((prevWords) =>
-                        prevWords.map((w) =>
-                            w.id === replacedWordId ? { ...w, available: true } : w
-                        )
-                    );
-                }
-
-                // Neues Wort in Ziel-Lücke setzen
-                updated[blankId] = wordId;
-                return updated;
-            });
-
-            // Das gezogene Wort als „nicht verfügbar“ markieren
-            setSolutionWords((prev) =>
-                prev.map((w) => (w.id === wordId ? { ...w, available: false } : w))
-            );
-        };
-
-        const handleReturnToBank = (wordId: string) => {
-            // Blank finden, in dem dieses Wort aktuell liegt
-            const blankId = Object.keys(answers).find(
-                (key) => answers[key] === wordId
-            );
-            if (!blankId) return;
-
-            // Wort wieder aktivieren
-            setSolutionWords((prev) =>
-                prev.map((w) => (w.id === wordId ? { ...w, available: true } : w))
-            );
-
-            // Blank leeren
-            setAnswers((prev) => {
-                const copy = { ...prev };
-                delete copy[blankId];
-                return copy;
-            });
-        };
-
-        const handleQuickPlace = (wordId: string) => {
-            // erste freie Lücke finden
-            const firstEmptyBlank = blanks.find((blank) => !answers[blank.id]);
-            if (!firstEmptyBlank) return;
-
-            handleDropIntoBlank(firstEmptyBlank.id, wordId);
-        };
-
-        const clearBlank = (blankId: string) => {
-            const wordId = answers[blankId];
-            if (!wordId) return;
-
-            setSolutionWords((prev) =>
-                prev.map((w) => (w.id === wordId ? { ...w, available: true } : w))
-            );
-
-            setAnswers((prev) => {
-                const updated = { ...prev };
-                delete updated[blankId];
-                return updated;
-            });
-        };
-
-        const checkResults = () => {
-            // Zähle korrekte Antworten
-            const correctCount = blanks.reduce((acc, b) => {
-                const user = getUserAnswerText(b.id);
-                return acc + (isCorrectAnswer(user, b.correct) ? 1 : 0);
-            }, 0);
-            const total = blanks.length;
-
-            if (correctCount === total) {
-                setFeedback({
-                    type: "success",
-                    message: "🎉 Volltreffer! Alles korrekt. Super gemacht!",
-                });
-                onSubmit();
-            } else {
-                setFeedback({
-                    type: "error",
-                    message: `Noch nicht ganz: ${correctCount} von ${total} richtig. Schau dir die Lücken nochmal an und probier’s erneut.`,
-                });
-            }
-        };
-
-        return (
-            <SubBackground>
-                {/* --- Header --- */}
-                <ClozeHeader title={title} />
-
-                {/* --- Lösungsauswahl (nur wenn Lösungswörter sichtbar) --- */}
-                {showSolutionWords && (
-                    <SolutionWordBank
-                        words={solutionWords}
-                        onReturnToBank={handleReturnToBank}
-                        onQuickPlace={handleQuickPlace}
-                    />
-                )}
-
-                {/* --- Lückentext --- */}
-                <div className="flex flex-wrap gap-1 mb-4 text-lg leading-[1.6]">
-                    {clozeTextWithIds.map((part, i) => {
-                        if (part.type === "text") {
-                            return (
-                                <span key={i} className="text-gray-600 mt-1">
-                                    {part.content}
-                                </span>
-                            );
-                        }
-
-                        // --- Drag & Drop Modus ---
-                        if (showSolutionWords) {
-                            const currentAnswerId = answers[part.id];
-                            const currentWord =
-                                solutionWords.find((w) => w.id === currentAnswerId) || null;
-
-                            return (
-                                <ClozeBlank
-                                    key={part.id}
-                                    id={part.id}
-                                    showSolutionWords
-                                    currentWord={
-                                        currentWord
-                                            ? { id: currentWord.id, word: currentWord.word }
-                                            : null
-                                    }
-                                    onDropWord={(wordId) => handleDropIntoBlank(part.id, wordId)}
-                                    onCtrlClear={() => clearBlank(part.id)}
-                                />
-                            );
-                        }
-
-                        // --- Eingabe-Modus ---
-                        return (
-                            <ClozeBlank
-                                key={part.id}
-                                id={part.id}
-                                showSolutionWords={false}
-                                inputValue={answers[part.id] ?? ""}
-                                onInputChange={(value) =>
-                                    setAnswers((prev) => ({ ...prev, [part.id]: value }))
-                                }
-                            />
-                        );
-                    })}
-                </div>
-
-                {/* --- OK-Button --- */}
-                <ClozeSubmitButton
-                    label="Prüfen"
-                    disabled={!allFilled}
-                    onClick={checkResults}
+              return (
+                <ClozeBlank
+                  key={part.id}
+                  id={part.id}
+                  showSolutionWords
+                  currentWord={
+                    currentWord
+                      ? { id: currentWord.id, word: currentWord.word }
+                      : null
+                  }
+                  onDropWord={(wordId) => handleDropIntoBlank(part.id, wordId)}
+                  onCtrlClear={() => clearBlank(part.id)}
                 />
+              );
+            }
 
-                {/* --- Feedback unter dem Button --- */}
-                {feedback.type && (
-                    <div
-                        className={[
-                            "mt-3 rounded-md border px-3 py-2 text-sm",
-                            feedback.type === "success"
-                                ? "border-green-200 bg-green-50 text-green-700"
-                                : "border-red-200 bg-red-50 text-red-700",
-                        ].join(" ")}
-                        role="status"
-                        aria-live="polite"
-                    >
-                        {feedback.message}
-                    </div>
-                )}
-            </SubBackground>
-        );
-    }
+            // --- Eingabe-Modus ---
+            return (
+              <ClozeBlank
+                key={part.id}
+                id={part.id}
+                showSolutionWords={false}
+                inputValue={answers[part.id] ?? ""}
+                onInputChange={(value) =>
+                  setAnswers((prev) => ({ ...prev, [part.id]: value }))
+                }
+              />
+            );
+          })}
+        </div>
+
+        {/* --- OK-Button --- */}
+        <ClozeSubmitButton
+          label="Prüfen"
+          disabled={!allFilled}
+          onClick={checkResults}
+        />
+
+        {/* --- Feedback unter dem Button --- */}
+        {feedback.type && (
+          <div
+            className={[
+              "mt-3 rounded-md border px-3 py-2 text-sm",
+              feedback.type === "success"
+                ? "border-green-200 bg-green-50 text-green-700"
+                : "border-red-200 bg-red-50 text-red-700",
+            ].join(" ")}
+            role="status"
+            aria-live="polite"
+          >
+            {feedback.message}
+          </div>
+        )}
+      </SubBackground>
+    );
+  },
 );
 
 ClozeExercise.displayName = "ClozeExercise";

--- a/frontend/src/components/ui_elements/cloze_exercise/ClozeExercise.tsx
+++ b/frontend/src/components/ui_elements/cloze_exercise/ClozeExercise.tsx
@@ -1,0 +1,242 @@
+import { SubBackground } from "@/components/layouts";
+import { memo, useMemo, useState } from "react";
+import SolutionWordBank, { SolutionWord } from "./SolutionWordBank";
+import ClozeBlank from "./ClozeBlank";
+import ClozeHeader from "./ClozeHeader";
+import ClozeSubmitButton from "./ClozeSubmitButton";
+
+
+export interface ClozeExerciseProps {
+    title?: string;
+    clozeText: ClozeTextPart[];
+
+    // determines whether the correct answers are displayed
+    // above the text and drag'n'droppable into the clozes.
+    showSolutionWords: boolean;
+
+    // add wrong answers to the drag'n'droppable
+    // solution words to increase difficulty
+    wrongSolutionWords?: string[];
+
+    onSubmit: () => void;
+}
+
+export interface ClozeResult {
+    answers: Record<string, string>;
+    correct: boolean;
+    details: Record<string, { isCorrect: boolean; correctAnswers: string[] }>;
+}
+
+export type ClozeTextPart =
+    | { type: "text"; content: string }
+    | { type: "blank"; correct: string[] };
+
+type ClozeBlank = { type: "blank"; id: string; correct: string[] };
+
+const normalize = (s: string) => s.trim().toLowerCase();
+const isCorrectAnswer = (user: string, correct: string[]) =>
+    correct.some(c => normalize(c) === normalize(user));
+
+export const ClozeExercise = memo<ClozeExerciseProps>(
+    ({ title = "Fülle die Lücken aus:", clozeText, showSolutionWords = false, wrongSolutionWords = [], onSubmit }) => {
+
+        const clozeTextWithIds = useMemo(() => {
+            return clozeText.map((part, index) => {
+                if (part.type === "blank") {
+                    return { ...part, id: `${index}` };
+                }
+                return part;
+            });
+        }, [clozeText]);
+
+        const blanks = useMemo(
+            () => clozeTextWithIds.filter((t): t is ClozeBlank => t.type === "blank"),
+            [clozeTextWithIds]
+        );
+
+        const [answers, setAnswers] = useState<Record<string, string>>({});
+        const [solutionWords, setSolutionWords] = useState<SolutionWord[]>(() => {
+            if (!showSolutionWords)
+                return [];
+
+            const initialWords = [
+                ...clozeTextWithIds.filter(p => p.type === "blank").map(p => p.correct[0]),
+                ...wrongSolutionWords,
+            ].sort();
+
+            return initialWords.map((word, i) => ({ id: i.toString(), word, available: true }));
+        });
+
+        // Hilfsfunktion: gibt den Text zurück, den wir prüfen wollen (immer ein String)
+        const getUserAnswerText = (blankId: string) => {
+            const val = answers[blankId];
+            if (val == null) return ""; // keine Antwort
+
+            // Wenn der Drag & Drop-Modus aktiv ist, ist answers[blankId] eine word-id -> löse sie auf
+            if (showSolutionWords) {
+                const word = solutionWords.find(w => w.id === val);
+                return word?.word ?? "";
+            }
+
+            // Sonst: Eingabemodus -> val ist bereits der Text
+            return String(val);
+        };
+
+        const allFilled = blanks.every(b => getUserAnswerText(b.id).trim().length > 0);
+        const allCorrect = blanks.every(b => isCorrectAnswer(getUserAnswerText(b.id), b.correct));
+
+        const handleDropIntoBlank = (blankId: string, wordId: string) => {
+            const droppedWord = solutionWords.find(w => w.id === wordId);
+            if (!droppedWord) return;
+
+            // Finde, ob das Wort bereits woanders genutzt wurde
+            const previousBlankId = Object.entries(answers).find(
+                ([, id]) => id === wordId
+            )?.[0];
+
+            setAnswers(prev => {
+                const updated = { ...prev };
+
+                // Wenn das Wort schon irgendwo war → alte Lücke leeren
+                if (previousBlankId) {
+                    delete updated[previousBlankId];
+                }
+
+                // Wenn Ziel-Lücke schon ein anderes Wort hat → das andere Wort freigeben
+                const replacedWordId = prev[blankId];
+                if (replacedWordId && replacedWordId !== wordId) {
+                    setSolutionWords(prevWords =>
+                        prevWords.map(w =>
+                            w.id === replacedWordId ? { ...w, available: true } : w
+                        )
+                    );
+                }
+
+                // Neues Wort in Ziel-Lücke setzen
+                updated[blankId] = wordId;
+                return updated;
+            });
+
+            // Das gezogene Wort als „nicht verfügbar“ markieren
+            setSolutionWords(prev =>
+                prev.map(w =>
+                    w.id === wordId ? { ...w, available: false } : w
+                )
+            );
+        };
+
+        const handleReturnToBank = (wordId: string) => {
+            // Blank finden, in dem dieses Wort aktuell liegt
+            const blankId = Object.keys(answers).find(key => answers[key] === wordId);
+            if (!blankId)
+                return;
+
+            // Wort wieder aktivieren
+            setSolutionWords(prev =>
+                prev.map(w => (w.id === wordId ? { ...w, available: true } : w))
+            );
+
+            // Blank leeren
+            setAnswers(prev => {
+                const copy = { ...prev };
+                delete copy[blankId];
+                return copy;
+            });
+        }
+
+        const handleQuickPlace = (wordId: string) => {
+            // erste freie Lücke finden
+            const firstEmptyBlank = blanks.find((blank) => !answers[blank.id]);
+            if (!firstEmptyBlank) return;
+
+            handleDropIntoBlank(firstEmptyBlank.id, wordId);
+        };
+
+        const clearBlank = (blankId: string) => {
+            const wordId = answers[blankId];
+            if (!wordId) return;
+
+            setSolutionWords((prev) =>
+                prev.map((w) => (w.id === wordId ? { ...w, available: true } : w))
+            );
+
+            setAnswers((prev) => {
+                const updated = { ...prev };
+                delete updated[blankId];
+                return updated;
+            });
+        };
+
+        const checkResults = () => {
+            if (allCorrect)
+                onSubmit();
+        };
+
+        return (
+            <SubBackground>
+                {/* --- Header --- */}
+                <ClozeHeader title={title} />
+
+                {/* --- Lösungsauswahl (nur wenn Lösungswörter sichtbar) --- */}
+                {showSolutionWords && (
+                    <SolutionWordBank
+                        words={solutionWords}
+                        onReturnToBank={handleReturnToBank}
+                        onQuickPlace={handleQuickPlace}
+                    />
+                )}
+
+                {/* --- Lückentext --- */}
+                <div className="flex flex-wrap gap-1 mb-4 text-lg leading-[1.6]">
+                    {clozeTextWithIds.map((part, i) => {
+                        if (part.type === "text") {
+                            return (
+                                <span key={i} className="text-gray-600 mt-1">
+                                    {part.content}
+                                </span>
+                            );
+                        }
+
+                        // --- Drag & Drop Modus ---
+                        if (showSolutionWords) {
+                            const currentAnswerId = answers[part.id];
+                            const currentWord = solutionWords.find((w) => w.id === currentAnswerId) || null;
+
+                            return (
+                                <ClozeBlank
+                                    key={part.id}
+                                    id={part.id}
+                                    showSolutionWords
+                                    currentWord={currentWord ? { id: currentWord.id, word: currentWord.word } : null}
+                                    onDropWord={(wordId) => handleDropIntoBlank(part.id, wordId)}
+                                    onCtrlClear={() => clearBlank(part.id)}
+                                />
+                            );
+                        }
+
+                        // --- Eingabe-Modus ---
+                        return (
+                            <ClozeBlank
+                                key={part.id}
+                                id={part.id}
+                                showSolutionWords={false}
+                                inputValue={answers[part.id] ?? ""}
+                                onInputChange={(value) =>
+                                    setAnswers((prev) => ({ ...prev, [part.id]: value }))
+                                }
+                            />
+                        );
+                    })}
+                </div>
+
+                {/* --- OK-Button --- }*/}
+                <ClozeSubmitButton label="Prüfen" disabled={!allFilled} onClick={checkResults} />
+            </SubBackground>
+        );
+    }
+);
+
+
+ClozeExercise.displayName = "ClozeExercise"
+
+export default ClozeExercise;

--- a/frontend/src/components/ui_elements/cloze_exercise/ClozeExercise.tsx
+++ b/frontend/src/components/ui_elements/cloze_exercise/ClozeExercise.tsx
@@ -6,297 +6,297 @@ import ClozeHeader from "./ClozeHeader";
 import ClozeSubmitButton from "./ClozeSubmitButton";
 
 export interface ClozeExerciseProps {
-    title?: string;
-    clozeText: ClozeTextPart[];
+  title?: string;
+  clozeText: ClozeTextPart[];
 
-    // determines whether the correct answers are displayed
-    // above the text and drag'n'droppable into the clozes.
-    showSolutionWords: boolean;
+  // determines whether the correct answers are displayed
+  // above the text and drag'n'droppable into the clozes.
+  showSolutionWords: boolean;
 
-    // add wrong answers to the drag'n'droppable
-    // solution words to increase difficulty
-    wrongSolutionWords?: string[];
+  // add wrong answers to the drag'n'droppable
+  // solution words to increase difficulty
+  wrongSolutionWords?: string[];
 
-    onSubmit: () => void;
+  onSubmit: () => void;
 }
 
 export interface ClozeResult {
-    answers: Record<string, string>;
-    correct: boolean;
-    details: Record<string, { isCorrect: boolean; correctAnswers: string[] }>;
+  answers: Record<string, string>;
+  correct: boolean;
+  details: Record<string, { isCorrect: boolean; correctAnswers: string[] }>;
 }
 
 export type ClozeTextPart =
-    | { type: "text"; content: string }
-    | { type: "blank"; correct: string[] };
+  | { type: "text"; content: string }
+  | { type: "blank"; correct: string[] };
 
 type ClozeBlank = { type: "blank"; id: string; correct: string[] };
 
 const normalize = (s: string) => s.trim().toLowerCase();
 const isCorrectAnswer = (user: string, correct: string[]) =>
-    correct.some((c) => normalize(c) === normalize(user));
+  correct.some((c) => normalize(c) === normalize(user));
 
 export const ClozeExercise = memo<ClozeExerciseProps>(
-    ({
-        title = "Fülle die Lücken aus:",
-        clozeText,
-        showSolutionWords = false,
-        wrongSolutionWords = [],
-        onSubmit,
-    }) => {
-        const clozeTextWithIds = useMemo(() => {
-            return clozeText.map((part, index) => {
-                if (part.type === "blank") {
-                    return { ...part, id: `${index}` };
-                }
-                return part;
-            });
-        }, [clozeText]);
+  ({
+    title = "Fülle die Lücken aus:",
+    clozeText,
+    showSolutionWords = false,
+    wrongSolutionWords = [],
+    onSubmit,
+  }) => {
+    const clozeTextWithIds = useMemo(() => {
+      return clozeText.map((part, index) => {
+        if (part.type === "blank") {
+          return { ...part, id: `${index}` };
+        }
+        return part;
+      });
+    }, [clozeText]);
 
-        const blanks = useMemo(
-            () => clozeTextWithIds.filter((t): t is ClozeBlank => t.type === "blank"),
-            [clozeTextWithIds],
-        );
+    const blanks = useMemo(
+      () => clozeTextWithIds.filter((t): t is ClozeBlank => t.type === "blank"),
+      [clozeTextWithIds],
+    );
 
-        const [answers, setAnswers] = useState<Record<string, string>>({});
-        const [solutionWords, setSolutionWords] = useState<SolutionWord[]>(() => {
-            if (!showSolutionWords) return [];
+    const [answers, setAnswers] = useState<Record<string, string>>({});
+    const [solutionWords, setSolutionWords] = useState<SolutionWord[]>(() => {
+      if (!showSolutionWords) return [];
 
-            const initialWords = [
-                ...clozeTextWithIds
-                    .filter((p) => p.type === "blank")
-                    .map((p) => p.correct[0]),
-                ...wrongSolutionWords,
-            ].sort();
+      const initialWords = [
+        ...clozeTextWithIds
+          .filter((p) => p.type === "blank")
+          .map((p) => p.correct[0]),
+        ...wrongSolutionWords,
+      ].sort();
 
-            return initialWords.map((word, i) => ({
-                id: i.toString(),
-                word,
-                available: true,
-            }));
+      return initialWords.map((word, i) => ({
+        id: i.toString(),
+        word,
+        available: true,
+      }));
+    });
+
+    // --- Feedback-State unter dem Button ---
+    const [feedback, setFeedback] = useState<{
+      type: "success" | "error" | null;
+      message: string;
+    }>({ type: null, message: "" });
+
+    // Feedback zurücksetzen, sobald der/die Nutzer:in weiterarbeitet
+    useEffect(() => {
+      if (feedback.type) setFeedback({ type: null, message: "" });
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [answers]);
+
+    // Hilfsfunktion: gibt den Text zurück, den wir prüfen wollen (immer ein String)
+    const getUserAnswerText = (blankId: string) => {
+      const val = answers[blankId];
+      if (val == null) return ""; // keine Antwort
+
+      // Wenn der Drag & Drop-Modus aktiv ist, ist answers[blankId] eine word-id -> löse sie auf
+      if (showSolutionWords) {
+        const word = solutionWords.find((w) => w.id === val);
+        return word?.word ?? "";
+      }
+
+      // Sonst: Eingabemodus -> val ist bereits der Text
+      return String(val);
+    };
+
+    const allFilled = blanks.every(
+      (b) => getUserAnswerText(b.id).trim().length > 0,
+    );
+
+    const handleDropIntoBlank = (blankId: string, wordId: string) => {
+      const droppedWord = solutionWords.find((w) => w.id === wordId);
+      if (!droppedWord) return;
+
+      // Finde, ob das Wort bereits woanders genutzt wurde
+      const previousBlankId = Object.entries(answers).find(
+        ([, id]) => id === wordId,
+      )?.[0];
+
+      setAnswers((prev) => {
+        const updated = { ...prev };
+
+        // Wenn das Wort schon irgendwo war → alte Lücke leeren
+        if (previousBlankId) {
+          delete updated[previousBlankId];
+        }
+
+        // Wenn Ziel-Lücke schon ein anderes Wort hat → das andere Wort freigeben
+        const replacedWordId = prev[blankId];
+        if (replacedWordId && replacedWordId !== wordId) {
+          setSolutionWords((prevWords) =>
+            prevWords.map((w) =>
+              w.id === replacedWordId ? { ...w, available: true } : w,
+            ),
+          );
+        }
+
+        // Neues Wort in Ziel-Lücke setzen
+        updated[blankId] = wordId;
+        return updated;
+      });
+
+      // Das gezogene Wort als „nicht verfügbar“ markieren
+      setSolutionWords((prev) =>
+        prev.map((w) => (w.id === wordId ? { ...w, available: false } : w)),
+      );
+    };
+
+    const handleReturnToBank = (wordId: string) => {
+      // Blank finden, in dem dieses Wort aktuell liegt
+      const blankId = Object.keys(answers).find(
+        (key) => answers[key] === wordId,
+      );
+      if (!blankId) return;
+
+      // Wort wieder aktivieren
+      setSolutionWords((prev) =>
+        prev.map((w) => (w.id === wordId ? { ...w, available: true } : w)),
+      );
+
+      // Blank leeren
+      setAnswers((prev) => {
+        const copy = { ...prev };
+        delete copy[blankId];
+        return copy;
+      });
+    };
+
+    const handleQuickPlace = (wordId: string) => {
+      // erste freie Lücke finden
+      const firstEmptyBlank = blanks.find((blank) => !answers[blank.id]);
+      if (!firstEmptyBlank) return;
+
+      handleDropIntoBlank(firstEmptyBlank.id, wordId);
+    };
+
+    const clearBlank = (blankId: string) => {
+      const wordId = answers[blankId];
+      if (!wordId) return;
+
+      setSolutionWords((prev) =>
+        prev.map((w) => (w.id === wordId ? { ...w, available: true } : w)),
+      );
+
+      setAnswers((prev) => {
+        const updated = { ...prev };
+        delete updated[blankId];
+        return updated;
+      });
+    };
+
+    const checkResults = () => {
+      // Zähle korrekte Antworten
+      const correctCount = blanks.reduce((acc, b) => {
+        const user = getUserAnswerText(b.id);
+        return acc + (isCorrectAnswer(user, b.correct) ? 1 : 0);
+      }, 0);
+      const total = blanks.length;
+
+      if (correctCount === total) {
+        setFeedback({
+          type: "success",
+          message: "🎉 Alles richtig! Super gemacht!",
         });
+        onSubmit();
+      } else {
+        setFeedback({
+          type: "error",
+          message: `Noch nicht ganz: ${correctCount} von ${total} richtig. Schau dir die Lücken nochmal an und probier’s erneut.`,
+        });
+      }
+    };
 
-        // --- Feedback-State unter dem Button ---
-        const [feedback, setFeedback] = useState<{
-            type: "success" | "error" | null;
-            message: string;
-        }>({ type: null, message: "" });
+    return (
+      <SubBackground>
+        {/* --- Header --- */}
+        <ClozeHeader title={title} />
 
-        // Feedback zurücksetzen, sobald der/die Nutzer:in weiterarbeitet
-        useEffect(() => {
-            if (feedback.type) setFeedback({ type: null, message: "" });
-            // eslint-disable-next-line react-hooks/exhaustive-deps
-        }, [answers]);
+        {/* --- Lösungsauswahl (nur wenn Lösungswörter sichtbar) --- */}
+        {showSolutionWords && (
+          <SolutionWordBank
+            words={solutionWords}
+            onReturnToBank={handleReturnToBank}
+            onQuickPlace={handleQuickPlace}
+          />
+        )}
 
-        // Hilfsfunktion: gibt den Text zurück, den wir prüfen wollen (immer ein String)
-        const getUserAnswerText = (blankId: string) => {
-            const val = answers[blankId];
-            if (val == null) return ""; // keine Antwort
+        {/* --- Lückentext --- */}
+        <div className="flex flex-wrap gap-1 mb-4 text-lg leading-[1.6]">
+          {clozeTextWithIds.map((part, i) => {
+            if (part.type === "text") {
+              return (
+                <span key={i} className="text-gray-600 mt-1">
+                  {part.content}
+                </span>
+              );
+            }
 
-            // Wenn der Drag & Drop-Modus aktiv ist, ist answers[blankId] eine word-id -> löse sie auf
+            // --- Drag & Drop Modus ---
             if (showSolutionWords) {
-                const word = solutionWords.find((w) => w.id === val);
-                return word?.word ?? "";
-            }
+              const currentAnswerId = answers[part.id];
+              const currentWord =
+                solutionWords.find((w) => w.id === currentAnswerId) || null;
 
-            // Sonst: Eingabemodus -> val ist bereits der Text
-            return String(val);
-        };
-
-        const allFilled = blanks.every(
-            (b) => getUserAnswerText(b.id).trim().length > 0,
-        );
-
-        const handleDropIntoBlank = (blankId: string, wordId: string) => {
-            const droppedWord = solutionWords.find((w) => w.id === wordId);
-            if (!droppedWord) return;
-
-            // Finde, ob das Wort bereits woanders genutzt wurde
-            const previousBlankId = Object.entries(answers).find(
-                ([, id]) => id === wordId,
-            )?.[0];
-
-            setAnswers((prev) => {
-                const updated = { ...prev };
-
-                // Wenn das Wort schon irgendwo war → alte Lücke leeren
-                if (previousBlankId) {
-                    delete updated[previousBlankId];
-                }
-
-                // Wenn Ziel-Lücke schon ein anderes Wort hat → das andere Wort freigeben
-                const replacedWordId = prev[blankId];
-                if (replacedWordId && replacedWordId !== wordId) {
-                    setSolutionWords((prevWords) =>
-                        prevWords.map((w) =>
-                            w.id === replacedWordId ? { ...w, available: true } : w,
-                        ),
-                    );
-                }
-
-                // Neues Wort in Ziel-Lücke setzen
-                updated[blankId] = wordId;
-                return updated;
-            });
-
-            // Das gezogene Wort als „nicht verfügbar“ markieren
-            setSolutionWords((prev) =>
-                prev.map((w) => (w.id === wordId ? { ...w, available: false } : w)),
-            );
-        };
-
-        const handleReturnToBank = (wordId: string) => {
-            // Blank finden, in dem dieses Wort aktuell liegt
-            const blankId = Object.keys(answers).find(
-                (key) => answers[key] === wordId,
-            );
-            if (!blankId) return;
-
-            // Wort wieder aktivieren
-            setSolutionWords((prev) =>
-                prev.map((w) => (w.id === wordId ? { ...w, available: true } : w)),
-            );
-
-            // Blank leeren
-            setAnswers((prev) => {
-                const copy = { ...prev };
-                delete copy[blankId];
-                return copy;
-            });
-        };
-
-        const handleQuickPlace = (wordId: string) => {
-            // erste freie Lücke finden
-            const firstEmptyBlank = blanks.find((blank) => !answers[blank.id]);
-            if (!firstEmptyBlank) return;
-
-            handleDropIntoBlank(firstEmptyBlank.id, wordId);
-        };
-
-        const clearBlank = (blankId: string) => {
-            const wordId = answers[blankId];
-            if (!wordId) return;
-
-            setSolutionWords((prev) =>
-                prev.map((w) => (w.id === wordId ? { ...w, available: true } : w)),
-            );
-
-            setAnswers((prev) => {
-                const updated = { ...prev };
-                delete updated[blankId];
-                return updated;
-            });
-        };
-
-        const checkResults = () => {
-            // Zähle korrekte Antworten
-            const correctCount = blanks.reduce((acc, b) => {
-                const user = getUserAnswerText(b.id);
-                return acc + (isCorrectAnswer(user, b.correct) ? 1 : 0);
-            }, 0);
-            const total = blanks.length;
-
-            if (correctCount === total) {
-                setFeedback({
-                    type: "success",
-                    message: "🎉 Alles richtig! Super gemacht!",
-                });
-                onSubmit();
-            } else {
-                setFeedback({
-                    type: "error",
-                    message: `Noch nicht ganz: ${correctCount} von ${total} richtig. Schau dir die Lücken nochmal an und probier’s erneut.`,
-                });
-            }
-        };
-
-        return (
-            <SubBackground>
-                {/* --- Header --- */}
-                <ClozeHeader title={title} />
-
-                {/* --- Lösungsauswahl (nur wenn Lösungswörter sichtbar) --- */}
-                {showSolutionWords && (
-                    <SolutionWordBank
-                        words={solutionWords}
-                        onReturnToBank={handleReturnToBank}
-                        onQuickPlace={handleQuickPlace}
-                    />
-                )}
-
-                {/* --- Lückentext --- */}
-                <div className="flex flex-wrap gap-1 mb-4 text-lg leading-[1.6]">
-                    {clozeTextWithIds.map((part, i) => {
-                        if (part.type === "text") {
-                            return (
-                                <span key={i} className="text-gray-600 mt-1">
-                                    {part.content}
-                                </span>
-                            );
-                        }
-
-                        // --- Drag & Drop Modus ---
-                        if (showSolutionWords) {
-                            const currentAnswerId = answers[part.id];
-                            const currentWord =
-                                solutionWords.find((w) => w.id === currentAnswerId) || null;
-
-                            return (
-                                <ClozeBlank
-                                    key={part.id}
-                                    id={part.id}
-                                    showSolutionWords
-                                    currentWord={
-                                        currentWord
-                                            ? { id: currentWord.id, word: currentWord.word }
-                                            : null
-                                    }
-                                    onDropWord={(wordId) => handleDropIntoBlank(part.id, wordId)}
-                                    onCtrlClear={() => clearBlank(part.id)}
-                                />
-                            );
-                        }
-
-                        // --- Eingabe-Modus ---
-                        return (
-                            <ClozeBlank
-                                key={part.id}
-                                id={part.id}
-                                showSolutionWords={false}
-                                inputValue={answers[part.id] ?? ""}
-                                onInputChange={(value) =>
-                                    setAnswers((prev) => ({ ...prev, [part.id]: value }))
-                                }
-                            />
-                        );
-                    })}
-                </div>
-
-                {/* --- OK-Button --- */}
-                <ClozeSubmitButton
-                    label="Prüfen"
-                    disabled={!allFilled}
-                    onClick={checkResults}
+              return (
+                <ClozeBlank
+                  key={part.id}
+                  id={part.id}
+                  showSolutionWords
+                  currentWord={
+                    currentWord
+                      ? { id: currentWord.id, word: currentWord.word }
+                      : null
+                  }
+                  onDropWord={(wordId) => handleDropIntoBlank(part.id, wordId)}
+                  onCtrlClear={() => clearBlank(part.id)}
                 />
+              );
+            }
 
-                {/* --- Feedback unter dem Button --- */}
-                {feedback.type && (
-                    <div
-                        className={[
-                            "mt-3 rounded-md border px-3 py-2 text-sm",
-                            feedback.type === "success"
-                                ? "border-green-200 bg-green-50 text-green-700"
-                                : "border-red-200 bg-red-50 text-red-700",
-                        ].join(" ")}
-                        role="status"
-                        aria-live="polite"
-                    >
-                        {feedback.message}
-                    </div>
-                )}
-            </SubBackground>
-        );
-    },
+            // --- Eingabe-Modus ---
+            return (
+              <ClozeBlank
+                key={part.id}
+                id={part.id}
+                showSolutionWords={false}
+                inputValue={answers[part.id] ?? ""}
+                onInputChange={(value) =>
+                  setAnswers((prev) => ({ ...prev, [part.id]: value }))
+                }
+              />
+            );
+          })}
+        </div>
+
+        {/* --- OK-Button --- */}
+        <ClozeSubmitButton
+          label="Prüfen"
+          disabled={!allFilled}
+          onClick={checkResults}
+        />
+
+        {/* --- Feedback unter dem Button --- */}
+        {feedback.type && (
+          <div
+            className={[
+              "mt-3 rounded-md border px-3 py-2 text-sm",
+              feedback.type === "success"
+                ? "border-green-200 bg-green-50 text-green-700"
+                : "border-red-200 bg-red-50 text-red-700",
+            ].join(" ")}
+            role="status"
+            aria-live="polite"
+          >
+            {feedback.message}
+          </div>
+        )}
+      </SubBackground>
+    );
+  },
 );
 
 ClozeExercise.displayName = "ClozeExercise";

--- a/frontend/src/components/ui_elements/cloze_exercise/ClozeExercise.tsx
+++ b/frontend/src/components/ui_elements/cloze_exercise/ClozeExercise.tsx
@@ -34,11 +34,16 @@ type ClozeBlank = { type: "blank"; id: string; correct: string[] };
 
 const normalize = (s: string) => s.trim().toLowerCase();
 const isCorrectAnswer = (user: string, correct: string[]) =>
-    correct.some(c => normalize(c) === normalize(user));
+    correct.some((c) => normalize(c) === normalize(user));
 
 export const ClozeExercise = memo<ClozeExerciseProps>(
-    ({ title = "Fülle die Lücken aus:", clozeText, showSolutionWords = false, wrongSolutionWords = [], onSubmit }) => {
-
+    ({
+        title = "Fülle die Lücken aus:",
+        clozeText,
+        showSolutionWords = false,
+        wrongSolutionWords = [],
+        onSubmit,
+    }) => {
         const clozeTextWithIds = useMemo(() => {
             return clozeText.map((part, index) => {
                 if (part.type === "blank") {
@@ -50,7 +55,7 @@ export const ClozeExercise = memo<ClozeExerciseProps>(
 
         const blanks = useMemo(
             () => clozeTextWithIds.filter((t): t is ClozeBlank => t.type === "blank"),
-            [clozeTextWithIds],
+            [clozeTextWithIds]
         );
 
         const [answers, setAnswers] = useState<Record<string, string>>({});
@@ -64,8 +69,24 @@ export const ClozeExercise = memo<ClozeExerciseProps>(
                 ...wrongSolutionWords,
             ].sort();
 
-            return initialWords.map((word, i) => ({ id: i.toString(), word, available: true }));
+            return initialWords.map((word, i) => ({
+                id: i.toString(),
+                word,
+                available: true,
+            }));
         });
+
+        // --- Feedback-State unter dem Button ---
+        const [feedback, setFeedback] = useState<{
+            type: "success" | "error" | null;
+            message: string;
+        }>({ type: null, message: "" });
+
+        // Feedback zurücksetzen, sobald der/die Nutzer:in weiterarbeitet
+        useEffect(() => {
+            if (feedback.type) setFeedback({ type: null, message: "" });
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, [answers]);
 
         // Hilfsfunktion: gibt den Text zurück, den wir prüfen wollen (immer ein String)
         const getUserAnswerText = (blankId: string) => {
@@ -82,8 +103,9 @@ export const ClozeExercise = memo<ClozeExerciseProps>(
             return String(val);
         };
 
-        const allFilled = blanks.every(b => getUserAnswerText(b.id).trim().length > 0);
-        const allCorrect = blanks.every(b => isCorrectAnswer(getUserAnswerText(b.id), b.correct));
+        const allFilled = blanks.every(
+            (b) => getUserAnswerText(b.id).trim().length > 0
+        );
 
         const handleDropIntoBlank = (blankId: string, wordId: string) => {
             const droppedWord = solutionWords.find((w) => w.id === wordId);
@@ -91,7 +113,7 @@ export const ClozeExercise = memo<ClozeExerciseProps>(
 
             // Finde, ob das Wort bereits woanders genutzt wurde
             const previousBlankId = Object.entries(answers).find(
-                ([, id]) => id === wordId,
+                ([, id]) => id === wordId
             )?.[0];
 
             setAnswers((prev) => {
@@ -107,8 +129,8 @@ export const ClozeExercise = memo<ClozeExerciseProps>(
                 if (replacedWordId && replacedWordId !== wordId) {
                     setSolutionWords((prevWords) =>
                         prevWords.map((w) =>
-                            w.id === replacedWordId ? { ...w, available: true } : w,
-                        ),
+                            w.id === replacedWordId ? { ...w, available: true } : w
+                        )
                     );
                 }
 
@@ -119,28 +141,29 @@ export const ClozeExercise = memo<ClozeExerciseProps>(
 
             // Das gezogene Wort als „nicht verfügbar“ markieren
             setSolutionWords((prev) =>
-                prev.map((w) => (w.id === wordId ? { ...w, available: false } : w)),
+                prev.map((w) => (w.id === wordId ? { ...w, available: false } : w))
             );
         };
 
         const handleReturnToBank = (wordId: string) => {
             // Blank finden, in dem dieses Wort aktuell liegt
-            const blankId = Object.keys(answers).find(key => answers[key] === wordId);
-            if (!blankId)
-                return;
+            const blankId = Object.keys(answers).find(
+                (key) => answers[key] === wordId
+            );
+            if (!blankId) return;
 
             // Wort wieder aktivieren
             setSolutionWords((prev) =>
-                prev.map((w) => (w.id === wordId ? { ...w, available: true } : w)),
+                prev.map((w) => (w.id === wordId ? { ...w, available: true } : w))
             );
 
             // Blank leeren
-            setAnswers(prev => {
+            setAnswers((prev) => {
                 const copy = { ...prev };
                 delete copy[blankId];
                 return copy;
             });
-        }
+        };
 
         const handleQuickPlace = (wordId: string) => {
             // erste freie Lücke finden
@@ -155,7 +178,7 @@ export const ClozeExercise = memo<ClozeExerciseProps>(
             if (!wordId) return;
 
             setSolutionWords((prev) =>
-                prev.map((w) => (w.id === wordId ? { ...w, available: true } : w)),
+                prev.map((w) => (w.id === wordId ? { ...w, available: true } : w))
             );
 
             setAnswers((prev) => {
@@ -166,8 +189,25 @@ export const ClozeExercise = memo<ClozeExerciseProps>(
         };
 
         const checkResults = () => {
-            if (allCorrect)
+            // Zähle korrekte Antworten
+            const correctCount = blanks.reduce((acc, b) => {
+                const user = getUserAnswerText(b.id);
+                return acc + (isCorrectAnswer(user, b.correct) ? 1 : 0);
+            }, 0);
+            const total = blanks.length;
+
+            if (correctCount === total) {
+                setFeedback({
+                    type: "success",
+                    message: "🎉 Volltreffer! Alles korrekt. Super gemacht!",
+                });
                 onSubmit();
+            } else {
+                setFeedback({
+                    type: "error",
+                    message: `Noch nicht ganz: ${correctCount} von ${total} richtig. Schau dir die Lücken nochmal an und probier’s erneut.`,
+                });
+            }
         };
 
         return (
@@ -206,7 +246,11 @@ export const ClozeExercise = memo<ClozeExerciseProps>(
                                     key={part.id}
                                     id={part.id}
                                     showSolutionWords
-                                    currentWord={currentWord ? { id: currentWord.id, word: currentWord.word } : null}
+                                    currentWord={
+                                        currentWord
+                                            ? { id: currentWord.id, word: currentWord.word }
+                                            : null
+                                    }
                                     onDropWord={(wordId) => handleDropIntoBlank(part.id, wordId)}
                                     onCtrlClear={() => clearBlank(part.id)}
                                 />
@@ -228,14 +272,32 @@ export const ClozeExercise = memo<ClozeExerciseProps>(
                     })}
                 </div>
 
-                {/* --- OK-Button --- }*/}
-                <ClozeSubmitButton label="Prüfen" disabled={!allFilled} onClick={checkResults} />
+                {/* --- OK-Button --- */}
+                <ClozeSubmitButton
+                    label="Prüfen"
+                    disabled={!allFilled}
+                    onClick={checkResults}
+                />
+
+                {/* --- Feedback unter dem Button --- */}
+                {feedback.type && (
+                    <div
+                        className={[
+                            "mt-3 rounded-md border px-3 py-2 text-sm",
+                            feedback.type === "success"
+                                ? "border-green-200 bg-green-50 text-green-700"
+                                : "border-red-200 bg-red-50 text-red-700",
+                        ].join(" ")}
+                        role="status"
+                        aria-live="polite"
+                    >
+                        {feedback.message}
+                    </div>
+                )}
             </SubBackground>
         );
     }
 );
 
-
-ClozeExercise.displayName = "ClozeExercise"
-
+ClozeExercise.displayName = "ClozeExercise";
 export default ClozeExercise;

--- a/frontend/src/components/ui_elements/cloze_exercise/ClozeExercise.tsx
+++ b/frontend/src/components/ui_elements/cloze_exercise/ClozeExercise.tsx
@@ -6,297 +6,297 @@ import ClozeHeader from "./ClozeHeader";
 import ClozeSubmitButton from "./ClozeSubmitButton";
 
 export interface ClozeExerciseProps {
-  title?: string;
-  clozeText: ClozeTextPart[];
+    title?: string;
+    clozeText: ClozeTextPart[];
 
-  // determines whether the correct answers are displayed
-  // above the text and drag'n'droppable into the clozes.
-  showSolutionWords: boolean;
+    // determines whether the correct answers are displayed
+    // above the text and drag'n'droppable into the clozes.
+    showSolutionWords: boolean;
 
-  // add wrong answers to the drag'n'droppable
-  // solution words to increase difficulty
-  wrongSolutionWords?: string[];
+    // add wrong answers to the drag'n'droppable
+    // solution words to increase difficulty
+    wrongSolutionWords?: string[];
 
-  onSubmit: () => void;
+    onSubmit: () => void;
 }
 
 export interface ClozeResult {
-  answers: Record<string, string>;
-  correct: boolean;
-  details: Record<string, { isCorrect: boolean; correctAnswers: string[] }>;
+    answers: Record<string, string>;
+    correct: boolean;
+    details: Record<string, { isCorrect: boolean; correctAnswers: string[] }>;
 }
 
 export type ClozeTextPart =
-  | { type: "text"; content: string }
-  | { type: "blank"; correct: string[] };
+    | { type: "text"; content: string }
+    | { type: "blank"; correct: string[] };
 
 type ClozeBlank = { type: "blank"; id: string; correct: string[] };
 
 const normalize = (s: string) => s.trim().toLowerCase();
 const isCorrectAnswer = (user: string, correct: string[]) =>
-  correct.some((c) => normalize(c) === normalize(user));
+    correct.some((c) => normalize(c) === normalize(user));
 
 export const ClozeExercise = memo<ClozeExerciseProps>(
-  ({
-    title = "Fülle die Lücken aus:",
-    clozeText,
-    showSolutionWords = false,
-    wrongSolutionWords = [],
-    onSubmit,
-  }) => {
-    const clozeTextWithIds = useMemo(() => {
-      return clozeText.map((part, index) => {
-        if (part.type === "blank") {
-          return { ...part, id: `${index}` };
-        }
-        return part;
-      });
-    }, [clozeText]);
-
-    const blanks = useMemo(
-      () => clozeTextWithIds.filter((t): t is ClozeBlank => t.type === "blank"),
-      [clozeTextWithIds],
-    );
-
-    const [answers, setAnswers] = useState<Record<string, string>>({});
-    const [solutionWords, setSolutionWords] = useState<SolutionWord[]>(() => {
-      if (!showSolutionWords) return [];
-
-      const initialWords = [
-        ...clozeTextWithIds
-          .filter((p) => p.type === "blank")
-          .map((p) => p.correct[0]),
-        ...wrongSolutionWords,
-      ].sort();
-
-      return initialWords.map((word, i) => ({
-        id: i.toString(),
-        word,
-        available: true,
-      }));
-    });
-
-    // --- Feedback-State unter dem Button ---
-    const [feedback, setFeedback] = useState<{
-      type: "success" | "error" | null;
-      message: string;
-    }>({ type: null, message: "" });
-
-    // Feedback zurücksetzen, sobald der/die Nutzer:in weiterarbeitet
-    useEffect(() => {
-      if (feedback.type) setFeedback({ type: null, message: "" });
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [answers]);
-
-    // Hilfsfunktion: gibt den Text zurück, den wir prüfen wollen (immer ein String)
-    const getUserAnswerText = (blankId: string) => {
-      const val = answers[blankId];
-      if (val == null) return ""; // keine Antwort
-
-      // Wenn der Drag & Drop-Modus aktiv ist, ist answers[blankId] eine word-id -> löse sie auf
-      if (showSolutionWords) {
-        const word = solutionWords.find((w) => w.id === val);
-        return word?.word ?? "";
-      }
-
-      // Sonst: Eingabemodus -> val ist bereits der Text
-      return String(val);
-    };
-
-    const allFilled = blanks.every(
-      (b) => getUserAnswerText(b.id).trim().length > 0,
-    );
-
-    const handleDropIntoBlank = (blankId: string, wordId: string) => {
-      const droppedWord = solutionWords.find((w) => w.id === wordId);
-      if (!droppedWord) return;
-
-      // Finde, ob das Wort bereits woanders genutzt wurde
-      const previousBlankId = Object.entries(answers).find(
-        ([, id]) => id === wordId,
-      )?.[0];
-
-      setAnswers((prev) => {
-        const updated = { ...prev };
-
-        // Wenn das Wort schon irgendwo war → alte Lücke leeren
-        if (previousBlankId) {
-          delete updated[previousBlankId];
-        }
-
-        // Wenn Ziel-Lücke schon ein anderes Wort hat → das andere Wort freigeben
-        const replacedWordId = prev[blankId];
-        if (replacedWordId && replacedWordId !== wordId) {
-          setSolutionWords((prevWords) =>
-            prevWords.map((w) =>
-              w.id === replacedWordId ? { ...w, available: true } : w,
-            ),
-          );
-        }
-
-        // Neues Wort in Ziel-Lücke setzen
-        updated[blankId] = wordId;
-        return updated;
-      });
-
-      // Das gezogene Wort als „nicht verfügbar“ markieren
-      setSolutionWords((prev) =>
-        prev.map((w) => (w.id === wordId ? { ...w, available: false } : w)),
-      );
-    };
-
-    const handleReturnToBank = (wordId: string) => {
-      // Blank finden, in dem dieses Wort aktuell liegt
-      const blankId = Object.keys(answers).find(
-        (key) => answers[key] === wordId,
-      );
-      if (!blankId) return;
-
-      // Wort wieder aktivieren
-      setSolutionWords((prev) =>
-        prev.map((w) => (w.id === wordId ? { ...w, available: true } : w)),
-      );
-
-      // Blank leeren
-      setAnswers((prev) => {
-        const copy = { ...prev };
-        delete copy[blankId];
-        return copy;
-      });
-    };
-
-    const handleQuickPlace = (wordId: string) => {
-      // erste freie Lücke finden
-      const firstEmptyBlank = blanks.find((blank) => !answers[blank.id]);
-      if (!firstEmptyBlank) return;
-
-      handleDropIntoBlank(firstEmptyBlank.id, wordId);
-    };
-
-    const clearBlank = (blankId: string) => {
-      const wordId = answers[blankId];
-      if (!wordId) return;
-
-      setSolutionWords((prev) =>
-        prev.map((w) => (w.id === wordId ? { ...w, available: true } : w)),
-      );
-
-      setAnswers((prev) => {
-        const updated = { ...prev };
-        delete updated[blankId];
-        return updated;
-      });
-    };
-
-    const checkResults = () => {
-      // Zähle korrekte Antworten
-      const correctCount = blanks.reduce((acc, b) => {
-        const user = getUserAnswerText(b.id);
-        return acc + (isCorrectAnswer(user, b.correct) ? 1 : 0);
-      }, 0);
-      const total = blanks.length;
-
-      if (correctCount === total) {
-        setFeedback({
-          type: "success",
-          message: "🎉 Volltreffer! Alles korrekt. Super gemacht!",
-        });
-        onSubmit();
-      } else {
-        setFeedback({
-          type: "error",
-          message: `Noch nicht ganz: ${correctCount} von ${total} richtig. Schau dir die Lücken nochmal an und probier’s erneut.`,
-        });
-      }
-    };
-
-    return (
-      <SubBackground>
-        {/* --- Header --- */}
-        <ClozeHeader title={title} />
-
-        {/* --- Lösungsauswahl (nur wenn Lösungswörter sichtbar) --- */}
-        {showSolutionWords && (
-          <SolutionWordBank
-            words={solutionWords}
-            onReturnToBank={handleReturnToBank}
-            onQuickPlace={handleQuickPlace}
-          />
-        )}
-
-        {/* --- Lückentext --- */}
-        <div className="flex flex-wrap gap-1 mb-4 text-lg leading-[1.6]">
-          {clozeTextWithIds.map((part, i) => {
-            if (part.type === "text") {
-              return (
-                <span key={i} className="text-gray-600 mt-1">
-                  {part.content}
-                </span>
-              );
-            }
-
-            // --- Drag & Drop Modus ---
-            if (showSolutionWords) {
-              const currentAnswerId = answers[part.id];
-              const currentWord =
-                solutionWords.find((w) => w.id === currentAnswerId) || null;
-
-              return (
-                <ClozeBlank
-                  key={part.id}
-                  id={part.id}
-                  showSolutionWords
-                  currentWord={
-                    currentWord
-                      ? { id: currentWord.id, word: currentWord.word }
-                      : null
-                  }
-                  onDropWord={(wordId) => handleDropIntoBlank(part.id, wordId)}
-                  onCtrlClear={() => clearBlank(part.id)}
-                />
-              );
-            }
-
-            // --- Eingabe-Modus ---
-            return (
-              <ClozeBlank
-                key={part.id}
-                id={part.id}
-                showSolutionWords={false}
-                inputValue={answers[part.id] ?? ""}
-                onInputChange={(value) =>
-                  setAnswers((prev) => ({ ...prev, [part.id]: value }))
+    ({
+        title = "Fülle die Lücken aus:",
+        clozeText,
+        showSolutionWords = false,
+        wrongSolutionWords = [],
+        onSubmit,
+    }) => {
+        const clozeTextWithIds = useMemo(() => {
+            return clozeText.map((part, index) => {
+                if (part.type === "blank") {
+                    return { ...part, id: `${index}` };
                 }
-              />
+                return part;
+            });
+        }, [clozeText]);
+
+        const blanks = useMemo(
+            () => clozeTextWithIds.filter((t): t is ClozeBlank => t.type === "blank"),
+            [clozeTextWithIds],
+        );
+
+        const [answers, setAnswers] = useState<Record<string, string>>({});
+        const [solutionWords, setSolutionWords] = useState<SolutionWord[]>(() => {
+            if (!showSolutionWords) return [];
+
+            const initialWords = [
+                ...clozeTextWithIds
+                    .filter((p) => p.type === "blank")
+                    .map((p) => p.correct[0]),
+                ...wrongSolutionWords,
+            ].sort();
+
+            return initialWords.map((word, i) => ({
+                id: i.toString(),
+                word,
+                available: true,
+            }));
+        });
+
+        // --- Feedback-State unter dem Button ---
+        const [feedback, setFeedback] = useState<{
+            type: "success" | "error" | null;
+            message: string;
+        }>({ type: null, message: "" });
+
+        // Feedback zurücksetzen, sobald der/die Nutzer:in weiterarbeitet
+        useEffect(() => {
+            if (feedback.type) setFeedback({ type: null, message: "" });
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, [answers]);
+
+        // Hilfsfunktion: gibt den Text zurück, den wir prüfen wollen (immer ein String)
+        const getUserAnswerText = (blankId: string) => {
+            const val = answers[blankId];
+            if (val == null) return ""; // keine Antwort
+
+            // Wenn der Drag & Drop-Modus aktiv ist, ist answers[blankId] eine word-id -> löse sie auf
+            if (showSolutionWords) {
+                const word = solutionWords.find((w) => w.id === val);
+                return word?.word ?? "";
+            }
+
+            // Sonst: Eingabemodus -> val ist bereits der Text
+            return String(val);
+        };
+
+        const allFilled = blanks.every(
+            (b) => getUserAnswerText(b.id).trim().length > 0,
+        );
+
+        const handleDropIntoBlank = (blankId: string, wordId: string) => {
+            const droppedWord = solutionWords.find((w) => w.id === wordId);
+            if (!droppedWord) return;
+
+            // Finde, ob das Wort bereits woanders genutzt wurde
+            const previousBlankId = Object.entries(answers).find(
+                ([, id]) => id === wordId,
+            )?.[0];
+
+            setAnswers((prev) => {
+                const updated = { ...prev };
+
+                // Wenn das Wort schon irgendwo war → alte Lücke leeren
+                if (previousBlankId) {
+                    delete updated[previousBlankId];
+                }
+
+                // Wenn Ziel-Lücke schon ein anderes Wort hat → das andere Wort freigeben
+                const replacedWordId = prev[blankId];
+                if (replacedWordId && replacedWordId !== wordId) {
+                    setSolutionWords((prevWords) =>
+                        prevWords.map((w) =>
+                            w.id === replacedWordId ? { ...w, available: true } : w,
+                        ),
+                    );
+                }
+
+                // Neues Wort in Ziel-Lücke setzen
+                updated[blankId] = wordId;
+                return updated;
+            });
+
+            // Das gezogene Wort als „nicht verfügbar“ markieren
+            setSolutionWords((prev) =>
+                prev.map((w) => (w.id === wordId ? { ...w, available: false } : w)),
             );
-          })}
-        </div>
+        };
 
-        {/* --- OK-Button --- */}
-        <ClozeSubmitButton
-          label="Prüfen"
-          disabled={!allFilled}
-          onClick={checkResults}
-        />
+        const handleReturnToBank = (wordId: string) => {
+            // Blank finden, in dem dieses Wort aktuell liegt
+            const blankId = Object.keys(answers).find(
+                (key) => answers[key] === wordId,
+            );
+            if (!blankId) return;
 
-        {/* --- Feedback unter dem Button --- */}
-        {feedback.type && (
-          <div
-            className={[
-              "mt-3 rounded-md border px-3 py-2 text-sm",
-              feedback.type === "success"
-                ? "border-green-200 bg-green-50 text-green-700"
-                : "border-red-200 bg-red-50 text-red-700",
-            ].join(" ")}
-            role="status"
-            aria-live="polite"
-          >
-            {feedback.message}
-          </div>
-        )}
-      </SubBackground>
-    );
-  },
+            // Wort wieder aktivieren
+            setSolutionWords((prev) =>
+                prev.map((w) => (w.id === wordId ? { ...w, available: true } : w)),
+            );
+
+            // Blank leeren
+            setAnswers((prev) => {
+                const copy = { ...prev };
+                delete copy[blankId];
+                return copy;
+            });
+        };
+
+        const handleQuickPlace = (wordId: string) => {
+            // erste freie Lücke finden
+            const firstEmptyBlank = blanks.find((blank) => !answers[blank.id]);
+            if (!firstEmptyBlank) return;
+
+            handleDropIntoBlank(firstEmptyBlank.id, wordId);
+        };
+
+        const clearBlank = (blankId: string) => {
+            const wordId = answers[blankId];
+            if (!wordId) return;
+
+            setSolutionWords((prev) =>
+                prev.map((w) => (w.id === wordId ? { ...w, available: true } : w)),
+            );
+
+            setAnswers((prev) => {
+                const updated = { ...prev };
+                delete updated[blankId];
+                return updated;
+            });
+        };
+
+        const checkResults = () => {
+            // Zähle korrekte Antworten
+            const correctCount = blanks.reduce((acc, b) => {
+                const user = getUserAnswerText(b.id);
+                return acc + (isCorrectAnswer(user, b.correct) ? 1 : 0);
+            }, 0);
+            const total = blanks.length;
+
+            if (correctCount === total) {
+                setFeedback({
+                    type: "success",
+                    message: "🎉 Alles richtig! Super gemacht!",
+                });
+                onSubmit();
+            } else {
+                setFeedback({
+                    type: "error",
+                    message: `Noch nicht ganz: ${correctCount} von ${total} richtig. Schau dir die Lücken nochmal an und probier’s erneut.`,
+                });
+            }
+        };
+
+        return (
+            <SubBackground>
+                {/* --- Header --- */}
+                <ClozeHeader title={title} />
+
+                {/* --- Lösungsauswahl (nur wenn Lösungswörter sichtbar) --- */}
+                {showSolutionWords && (
+                    <SolutionWordBank
+                        words={solutionWords}
+                        onReturnToBank={handleReturnToBank}
+                        onQuickPlace={handleQuickPlace}
+                    />
+                )}
+
+                {/* --- Lückentext --- */}
+                <div className="flex flex-wrap gap-1 mb-4 text-lg leading-[1.6]">
+                    {clozeTextWithIds.map((part, i) => {
+                        if (part.type === "text") {
+                            return (
+                                <span key={i} className="text-gray-600 mt-1">
+                                    {part.content}
+                                </span>
+                            );
+                        }
+
+                        // --- Drag & Drop Modus ---
+                        if (showSolutionWords) {
+                            const currentAnswerId = answers[part.id];
+                            const currentWord =
+                                solutionWords.find((w) => w.id === currentAnswerId) || null;
+
+                            return (
+                                <ClozeBlank
+                                    key={part.id}
+                                    id={part.id}
+                                    showSolutionWords
+                                    currentWord={
+                                        currentWord
+                                            ? { id: currentWord.id, word: currentWord.word }
+                                            : null
+                                    }
+                                    onDropWord={(wordId) => handleDropIntoBlank(part.id, wordId)}
+                                    onCtrlClear={() => clearBlank(part.id)}
+                                />
+                            );
+                        }
+
+                        // --- Eingabe-Modus ---
+                        return (
+                            <ClozeBlank
+                                key={part.id}
+                                id={part.id}
+                                showSolutionWords={false}
+                                inputValue={answers[part.id] ?? ""}
+                                onInputChange={(value) =>
+                                    setAnswers((prev) => ({ ...prev, [part.id]: value }))
+                                }
+                            />
+                        );
+                    })}
+                </div>
+
+                {/* --- OK-Button --- */}
+                <ClozeSubmitButton
+                    label="Prüfen"
+                    disabled={!allFilled}
+                    onClick={checkResults}
+                />
+
+                {/* --- Feedback unter dem Button --- */}
+                {feedback.type && (
+                    <div
+                        className={[
+                            "mt-3 rounded-md border px-3 py-2 text-sm",
+                            feedback.type === "success"
+                                ? "border-green-200 bg-green-50 text-green-700"
+                                : "border-red-200 bg-red-50 text-red-700",
+                        ].join(" ")}
+                        role="status"
+                        aria-live="polite"
+                    >
+                        {feedback.message}
+                    </div>
+                )}
+            </SubBackground>
+        );
+    },
 );
 
 ClozeExercise.displayName = "ClozeExercise";

--- a/frontend/src/components/ui_elements/cloze_exercise/ClozeHeader.tsx
+++ b/frontend/src/components/ui_elements/cloze_exercise/ClozeHeader.tsx
@@ -1,0 +1,18 @@
+import { memo } from "react";
+import { FaPenToSquare } from "react-icons/fa6";
+
+interface ClozeHeaderProps {
+    title: string;
+}
+
+const ClozeHeader = memo<ClozeHeaderProps>(({ title }) => (
+    <div className="inline-flex items-center gap-2">
+        <div className="p-3 rounded-xl bg-dsp-orange_light">
+            <FaPenToSquare className="w-5 h-5 text-dsp-orange" />
+        </div>
+        <h1 className="text-lg text-gray-600">{title}</h1>
+    </div>
+));
+
+ClozeHeader.displayName = "ClozeHeader";
+export default ClozeHeader;

--- a/frontend/src/components/ui_elements/cloze_exercise/ClozeHeader.tsx
+++ b/frontend/src/components/ui_elements/cloze_exercise/ClozeHeader.tsx
@@ -2,16 +2,16 @@ import { memo } from "react";
 import { FaPenToSquare } from "react-icons/fa6";
 
 interface ClozeHeaderProps {
-    title: string;
+  title: string;
 }
 
 const ClozeHeader = memo<ClozeHeaderProps>(({ title }) => (
-    <div className="inline-flex items-center gap-2">
-        <div className="p-3 rounded-xl bg-dsp-orange_light">
-            <FaPenToSquare className="w-5 h-5 text-dsp-orange" />
-        </div>
-        <h1 className="text-lg text-gray-600">{title}</h1>
+  <div className="inline-flex items-center gap-2">
+    <div className="p-3 rounded-xl bg-dsp-orange_light">
+      <FaPenToSquare className="w-5 h-5 text-dsp-orange" />
     </div>
+    <h1 className="text-lg text-gray-600">{title}</h1>
+  </div>
 ));
 
 ClozeHeader.displayName = "ClozeHeader";

--- a/frontend/src/components/ui_elements/cloze_exercise/ClozeSubmitButton.tsx
+++ b/frontend/src/components/ui_elements/cloze_exercise/ClozeSubmitButton.tsx
@@ -1,0 +1,27 @@
+import { memo } from "react";
+
+interface ClozeSubmitButtonProps {
+    disabled: boolean;
+    label: string;
+    onClick: () => void;
+}
+
+const ClozeSubmitButton = memo<ClozeSubmitButtonProps>(
+    ({ disabled, label, onClick }) => (
+        <button
+            type="button"
+            disabled={disabled}
+            className={`w-auto text-left px-4 py-2 rounded-lg border transition
+        ${!disabled
+                    ? "bg-dsp-orange text-white border-orange-500 cursor-pointer"
+                    : "bg-gray-50 border-gray-300 opacity-60 cursor-not-allowed"}
+      `}
+            onClick={onClick}
+        >
+            {label}
+        </button>
+    )
+);
+
+ClozeSubmitButton.displayName = "ClozeSubmitButton";
+export default ClozeSubmitButton;

--- a/frontend/src/components/ui_elements/cloze_exercise/ClozeSubmitButton.tsx
+++ b/frontend/src/components/ui_elements/cloze_exercise/ClozeSubmitButton.tsx
@@ -1,26 +1,28 @@
 import { memo } from "react";
 
 interface ClozeSubmitButtonProps {
-    disabled: boolean;
-    label: string;
-    onClick: () => void;
+  disabled: boolean;
+  label: string;
+  onClick: () => void;
 }
 
 const ClozeSubmitButton = memo<ClozeSubmitButtonProps>(
-    ({ disabled, label, onClick }) => (
-        <button
-            type="button"
-            disabled={disabled}
-            className={`w-auto text-left px-4 py-2 rounded-lg border transition
-        ${!disabled
-                    ? "bg-dsp-orange text-white border-orange-500 cursor-pointer"
-                    : "bg-gray-50 border-gray-300 opacity-60 cursor-not-allowed"}
+  ({ disabled, label, onClick }) => (
+    <button
+      type="button"
+      disabled={disabled}
+      className={`w-auto text-left px-4 py-2 rounded-lg border transition
+        ${
+          !disabled
+            ? "bg-dsp-orange text-white border-orange-500 cursor-pointer"
+            : "bg-gray-50 border-gray-300 opacity-60 cursor-not-allowed"
+        }
       `}
-            onClick={onClick}
-        >
-            {label}
-        </button>
-    )
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  ),
 );
 
 ClozeSubmitButton.displayName = "ClozeSubmitButton";

--- a/frontend/src/components/ui_elements/cloze_exercise/SolutionWordBank.tsx
+++ b/frontend/src/components/ui_elements/cloze_exercise/SolutionWordBank.tsx
@@ -1,0 +1,63 @@
+import { memo } from "react";
+
+export type SolutionWord = { id: string; word: string; available: boolean };
+
+export interface SolutionWordBankProps {
+    words: SolutionWord[];
+    onReturnToBank: (wordId: string) => void;
+    onQuickPlace: (wordId: string) => void; // Ctrl/Cmd-Klick: erstes freies Blank füllen
+}
+
+const SolutionWordBank = memo<SolutionWordBankProps>(
+    ({ words, onReturnToBank, onQuickPlace }) => {
+        const handleDragStart = (
+            e: React.DragEvent<HTMLDivElement>,
+            wordId: string
+        ) => {
+            e.dataTransfer.setData("wordId", wordId);
+        };
+
+        const handleReturnToBankEvent = (e: React.DragEvent<HTMLDivElement>) => {
+            e.preventDefault();
+            const wordId = e.dataTransfer.getData("wordId");
+            if (wordId) onReturnToBank(wordId);
+        };
+
+        return (
+            <div
+                className="flex flex-wrap gap-2 mb-4"
+                data-testid="solution-words"
+                onDragOver={(e) => e.preventDefault()}
+                onDrop={handleReturnToBankEvent}
+            >
+                {words.map((word) => {
+                    const handleCtrlClick = (e: React.MouseEvent) => {
+                        if ((e.ctrlKey || e.metaKey) && word.available) {
+                            e.preventDefault();
+                            onQuickPlace(word.id);
+                        }
+                    };
+
+                    return (
+                        <div
+                            key={word.id}
+                            draggable={word.available}
+                            onDragStart={(e) => word.available && handleDragStart(e, word.id)}
+                            onClick={handleCtrlClick}
+                            data-testid={`wordbank-${word.id}`}
+                            className={`px-3 py-1 border rounded-xl select-none transition-colors ${word.available
+                                ? "bg-dsp-orange_light/50 border-dsp-orange_medium/60 cursor-grab hover:text-dsp-orange"
+                                : "bg-gray-100 border-gray-100 text-gray-500 cursor-not-allowed"
+                                }`}
+                        >
+                            {word.word}
+                        </div>
+                    );
+                })}
+            </div>
+        );
+    }
+);
+
+SolutionWordBank.displayName = "SolutionWordBank";
+export default SolutionWordBank;

--- a/frontend/src/components/ui_elements/cloze_exercise/SolutionWordBank.tsx
+++ b/frontend/src/components/ui_elements/cloze_exercise/SolutionWordBank.tsx
@@ -3,60 +3,61 @@ import { memo } from "react";
 export type SolutionWord = { id: string; word: string; available: boolean };
 
 export interface SolutionWordBankProps {
-    words: SolutionWord[];
-    onReturnToBank: (wordId: string) => void;
-    onQuickPlace: (wordId: string) => void; // Ctrl/Cmd-Klick: erstes freies Blank füllen
+  words: SolutionWord[];
+  onReturnToBank: (wordId: string) => void;
+  onQuickPlace: (wordId: string) => void; // Ctrl/Cmd-Klick: erstes freies Blank füllen
 }
 
 const SolutionWordBank = memo<SolutionWordBankProps>(
-    ({ words, onReturnToBank, onQuickPlace }) => {
-        const handleDragStart = (
-            e: React.DragEvent<HTMLDivElement>,
-            wordId: string
-        ) => {
-            e.dataTransfer.setData("wordId", wordId);
-        };
+  ({ words, onReturnToBank, onQuickPlace }) => {
+    const handleDragStart = (
+      e: React.DragEvent<HTMLDivElement>,
+      wordId: string,
+    ) => {
+      e.dataTransfer.setData("wordId", wordId);
+    };
 
-        const handleReturnToBankEvent = (e: React.DragEvent<HTMLDivElement>) => {
-            e.preventDefault();
-            const wordId = e.dataTransfer.getData("wordId");
-            if (wordId) onReturnToBank(wordId);
-        };
+    const handleReturnToBankEvent = (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const wordId = e.dataTransfer.getData("wordId");
+      if (wordId) onReturnToBank(wordId);
+    };
 
-        return (
+    return (
+      <div
+        className="flex flex-wrap gap-2 mb-4"
+        data-testid="solution-words"
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={handleReturnToBankEvent}
+      >
+        {words.map((word) => {
+          const handleCtrlClick = (e: React.MouseEvent) => {
+            if ((e.ctrlKey || e.metaKey) && word.available) {
+              e.preventDefault();
+              onQuickPlace(word.id);
+            }
+          };
+
+          return (
             <div
-                className="flex flex-wrap gap-2 mb-4"
-                data-testid="solution-words"
-                onDragOver={(e) => e.preventDefault()}
-                onDrop={handleReturnToBankEvent}
+              key={word.id}
+              draggable={word.available}
+              onDragStart={(e) => word.available && handleDragStart(e, word.id)}
+              onClick={handleCtrlClick}
+              data-testid={`wordbank-${word.id}`}
+              className={`px-3 py-1 border rounded-xl select-none transition-colors ${
+                word.available
+                  ? "bg-dsp-orange_light/50 border-dsp-orange_medium/60 cursor-grab hover:text-dsp-orange"
+                  : "bg-gray-100 border-gray-100 text-gray-500 cursor-not-allowed"
+              }`}
             >
-                {words.map((word) => {
-                    const handleCtrlClick = (e: React.MouseEvent) => {
-                        if ((e.ctrlKey || e.metaKey) && word.available) {
-                            e.preventDefault();
-                            onQuickPlace(word.id);
-                        }
-                    };
-
-                    return (
-                        <div
-                            key={word.id}
-                            draggable={word.available}
-                            onDragStart={(e) => word.available && handleDragStart(e, word.id)}
-                            onClick={handleCtrlClick}
-                            data-testid={`wordbank-${word.id}`}
-                            className={`px-3 py-1 border rounded-xl select-none transition-colors ${word.available
-                                ? "bg-dsp-orange_light/50 border-dsp-orange_medium/60 cursor-grab hover:text-dsp-orange"
-                                : "bg-gray-100 border-gray-100 text-gray-500 cursor-not-allowed"
-                                }`}
-                        >
-                            {word.word}
-                        </div>
-                    );
-                })}
+              {word.word}
             </div>
-        );
-    }
+          );
+        })}
+      </div>
+    );
+  },
 );
 
 SolutionWordBank.displayName = "SolutionWordBank";

--- a/frontend/tests/components/cloze-exercise/ClozeBlank.test.tsx
+++ b/frontend/tests/components/cloze-exercise/ClozeBlank.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import ClozeBlank from "@/components/ui_elements/cloze_exercise/ClozeBlank";
+
+// kleines Helferlein für dataTransfer im DnD
+function createDataTransfer(initial: Record<string, string> = {}) {
+    const store = { ...initial };
+    return {
+        setData: vi.fn((key: string, val: string) => { store[key] = val; }),
+        getData: vi.fn((key: string) => store[key]),
+        dropEffect: "move",
+        effectAllowed: "all",
+        files: [],
+        items: [],
+        types: Object.keys(store),
+    } as unknown as DataTransfer;
+}
+
+describe("ClozeBlank", () => {
+    it("Input-Modus: ruft onInputChange mit neuem Wert auf", () => {
+        const onInputChange = vi.fn();
+        render(
+            <ClozeBlank
+                id="b1"
+                showSolutionWords={false}
+                inputValue=""
+                onInputChange={onInputChange}
+            />
+        );
+
+        const input = screen.getByRole("textbox");
+        fireEvent.change(input, { target: { value: "Antwort" } });
+
+        expect(onInputChange).toHaveBeenCalledTimes(1);
+        expect(onInputChange).toHaveBeenCalledWith("Antwort");
+    });
+
+    it("DnD-Modus: zeigt currentWord-Text an, wenn belegt", () => {
+        render(
+            <ClozeBlank
+                id="b1"
+                showSolutionWords
+                currentWord={{ id: "w1", word: "Haus" }}
+            />
+        );
+        expect(screen.getByText("Haus")).toBeInTheDocument();
+    });
+
+    it("DnD-Modus: Drop triggert onDropWord mit wordId aus dataTransfer", () => {
+        const onDropWord = vi.fn();
+        render(<ClozeBlank id="b1" showSolutionWords onDropWord={onDropWord} />);
+
+        const blank = screen.getByTestId("blank-b1");
+        const dt = createDataTransfer({ wordId: "w42" });
+
+        // dragOver, dann drop (preventDefault wird intern aufgerufen)
+        fireEvent.dragOver(blank, { dataTransfer: dt });
+        fireEvent.drop(blank, { dataTransfer: dt });
+
+        expect(onDropWord).toHaveBeenCalledTimes(1);
+        expect(onDropWord).toHaveBeenCalledWith("w42");
+    });
+
+    it("DnD-Modus: Ctrl/Cmd-Klick auf belegte Lücke ruft onCtrlClear mit aktueller wordId", () => {
+        const onCtrlClear = vi.fn();
+        render(
+            <ClozeBlank
+                id="b1"
+                showSolutionWords
+                currentWord={{ id: "w1", word: "Haus" }}
+                onCtrlClear={onCtrlClear}
+            />
+        );
+
+        const blank = screen.getByTestId("blank-b1");
+        fireEvent.click(blank, { ctrlKey: true });
+
+        expect(onCtrlClear).toHaveBeenCalledTimes(1);
+        expect(onCtrlClear).toHaveBeenCalledWith("w1");
+    });
+
+    it("DnD-Modus: Ctrl/Cmd-Klick macht nichts, wenn kein currentWord gesetzt ist", () => {
+        const onCtrlClear = vi.fn();
+        render(
+            <ClozeBlank
+                id="b1"
+                showSolutionWords
+                currentWord={null}
+                onCtrlClear={onCtrlClear}
+            />
+        );
+
+        const blank = screen.getByTestId("blank-b1");
+        fireEvent.click(blank, { metaKey: true }); // macOS-Variante
+
+        expect(onCtrlClear).not.toHaveBeenCalled();
+    });
+
+    it("Drop ohne onDropWord verursacht keinen Fehler", () => {
+        render(<ClozeBlank id="b1" showSolutionWords />);
+        const blank = screen.getByTestId("blank-b1");
+        const dt = createDataTransfer({ wordId: "wX" });
+
+        // Erwartung: kein Throw
+        expect(() => {
+            fireEvent.dragOver(blank, { dataTransfer: dt });
+            fireEvent.drop(blank, { dataTransfer: dt });
+        }).not.toThrow();
+    });
+});

--- a/frontend/tests/components/cloze-exercise/ClozeBlank.test.tsx
+++ b/frontend/tests/components/cloze-exercise/ClozeBlank.test.tsx
@@ -5,107 +5,109 @@ import ClozeBlank from "@/components/ui_elements/cloze_exercise/ClozeBlank";
 
 // kleines Helferlein für dataTransfer im DnD
 function createDataTransfer(initial: Record<string, string> = {}) {
-    const store = { ...initial };
-    return {
-        setData: vi.fn((key: string, val: string) => { store[key] = val; }),
-        getData: vi.fn((key: string) => store[key]),
-        dropEffect: "move",
-        effectAllowed: "all",
-        files: [],
-        items: [],
-        types: Object.keys(store),
-    } as unknown as DataTransfer;
+  const store = { ...initial };
+  return {
+    setData: vi.fn((key: string, val: string) => {
+      store[key] = val;
+    }),
+    getData: vi.fn((key: string) => store[key]),
+    dropEffect: "move",
+    effectAllowed: "all",
+    files: [],
+    items: [],
+    types: Object.keys(store),
+  } as unknown as DataTransfer;
 }
 
 describe("ClozeBlank", () => {
-    it("Input-Modus: ruft onInputChange mit neuem Wert auf", () => {
-        const onInputChange = vi.fn();
-        render(
-            <ClozeBlank
-                id="b1"
-                showSolutionWords={false}
-                inputValue=""
-                onInputChange={onInputChange}
-            />
-        );
+  it("Input-Modus: ruft onInputChange mit neuem Wert auf", () => {
+    const onInputChange = vi.fn();
+    render(
+      <ClozeBlank
+        id="b1"
+        showSolutionWords={false}
+        inputValue=""
+        onInputChange={onInputChange}
+      />,
+    );
 
-        const input = screen.getByRole("textbox");
-        fireEvent.change(input, { target: { value: "Antwort" } });
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Antwort" } });
 
-        expect(onInputChange).toHaveBeenCalledTimes(1);
-        expect(onInputChange).toHaveBeenCalledWith("Antwort");
-    });
+    expect(onInputChange).toHaveBeenCalledTimes(1);
+    expect(onInputChange).toHaveBeenCalledWith("Antwort");
+  });
 
-    it("DnD-Modus: zeigt currentWord-Text an, wenn belegt", () => {
-        render(
-            <ClozeBlank
-                id="b1"
-                showSolutionWords
-                currentWord={{ id: "w1", word: "Haus" }}
-            />
-        );
-        expect(screen.getByText("Haus")).toBeInTheDocument();
-    });
+  it("DnD-Modus: zeigt currentWord-Text an, wenn belegt", () => {
+    render(
+      <ClozeBlank
+        id="b1"
+        showSolutionWords
+        currentWord={{ id: "w1", word: "Haus" }}
+      />,
+    );
+    expect(screen.getByText("Haus")).toBeInTheDocument();
+  });
 
-    it("DnD-Modus: Drop triggert onDropWord mit wordId aus dataTransfer", () => {
-        const onDropWord = vi.fn();
-        render(<ClozeBlank id="b1" showSolutionWords onDropWord={onDropWord} />);
+  it("DnD-Modus: Drop triggert onDropWord mit wordId aus dataTransfer", () => {
+    const onDropWord = vi.fn();
+    render(<ClozeBlank id="b1" showSolutionWords onDropWord={onDropWord} />);
 
-        const blank = screen.getByTestId("blank-b1");
-        const dt = createDataTransfer({ wordId: "w42" });
+    const blank = screen.getByTestId("blank-b1");
+    const dt = createDataTransfer({ wordId: "w42" });
 
-        // dragOver, dann drop (preventDefault wird intern aufgerufen)
-        fireEvent.dragOver(blank, { dataTransfer: dt });
-        fireEvent.drop(blank, { dataTransfer: dt });
+    // dragOver, dann drop (preventDefault wird intern aufgerufen)
+    fireEvent.dragOver(blank, { dataTransfer: dt });
+    fireEvent.drop(blank, { dataTransfer: dt });
 
-        expect(onDropWord).toHaveBeenCalledTimes(1);
-        expect(onDropWord).toHaveBeenCalledWith("w42");
-    });
+    expect(onDropWord).toHaveBeenCalledTimes(1);
+    expect(onDropWord).toHaveBeenCalledWith("w42");
+  });
 
-    it("DnD-Modus: Ctrl/Cmd-Klick auf belegte Lücke ruft onCtrlClear mit aktueller wordId", () => {
-        const onCtrlClear = vi.fn();
-        render(
-            <ClozeBlank
-                id="b1"
-                showSolutionWords
-                currentWord={{ id: "w1", word: "Haus" }}
-                onCtrlClear={onCtrlClear}
-            />
-        );
+  it("DnD-Modus: Ctrl/Cmd-Klick auf belegte Lücke ruft onCtrlClear mit aktueller wordId", () => {
+    const onCtrlClear = vi.fn();
+    render(
+      <ClozeBlank
+        id="b1"
+        showSolutionWords
+        currentWord={{ id: "w1", word: "Haus" }}
+        onCtrlClear={onCtrlClear}
+      />,
+    );
 
-        const blank = screen.getByTestId("blank-b1");
-        fireEvent.click(blank, { ctrlKey: true });
+    const blank = screen.getByTestId("blank-b1");
+    fireEvent.click(blank, { ctrlKey: true });
 
-        expect(onCtrlClear).toHaveBeenCalledTimes(1);
-        expect(onCtrlClear).toHaveBeenCalledWith("w1");
-    });
+    expect(onCtrlClear).toHaveBeenCalledTimes(1);
+    expect(onCtrlClear).toHaveBeenCalledWith("w1");
+  });
 
-    it("DnD-Modus: Ctrl/Cmd-Klick macht nichts, wenn kein currentWord gesetzt ist", () => {
-        const onCtrlClear = vi.fn();
-        render(
-            <ClozeBlank
-                id="b1"
-                showSolutionWords
-                currentWord={null}
-                onCtrlClear={onCtrlClear}
-            />
-        );
+  it("DnD-Modus: Ctrl/Cmd-Klick macht nichts, wenn kein currentWord gesetzt ist", () => {
+    const onCtrlClear = vi.fn();
+    render(
+      <ClozeBlank
+        id="b1"
+        showSolutionWords
+        currentWord={null}
+        onCtrlClear={onCtrlClear}
+      />,
+    );
 
-        const blank = screen.getByTestId("blank-b1");
-        fireEvent.click(blank, { metaKey: true }); // macOS-Variante
+    const blank = screen.getByTestId("blank-b1");
+    fireEvent.click(blank, { metaKey: true }); // macOS-Variante
 
-        expect(onCtrlClear).not.toHaveBeenCalled();
-    });
+    expect(onCtrlClear).not.toHaveBeenCalled();
+  });
 
-    it("Drop ohne onDropWord verursacht keinen Fehler", () => {
-        render(<ClozeBlank id="b1" showSolutionWords />);
-        const blank = screen.getByTestId("blank-b1");
-        const dt = createDataTransfer({ wordId: "wX" });
+  it("Drop ohne onDropWord verursacht keinen Fehler", () => {
+    render(<ClozeBlank id="b1" showSolutionWords />);
+    const blank = screen.getByTestId("blank-b1");
+    const dt = createDataTransfer({ wordId: "wX" });
 
-        // Erwartung: kein Throw
-        expect(() => {
-            fireEvent.dragOver(blank, { dataTransfer: dt });
-            fireEvent.drop(blank, { dataTransfer: dt });
-        }).not.toThrow();
-    });
+    // Erwartung: kein Throw
+    expect(() => {
+      fireEvent.dragOver(blank, { dataTransfer: dt });
+      fireEvent.drop(blank, { dataTransfer: dt });
+    }).not.toThrow();
+  });
 });

--- a/frontend/tests/components/cloze-exercise/ClozeExercise.test.tsx
+++ b/frontend/tests/components/cloze-exercise/ClozeExercise.test.tsx
@@ -2,255 +2,263 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import React from "react";
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
-import ClozeExercise, { ClozeTextPart, ClozeResult } from "@/components/ui_elements/cloze_exercise/ClozeExercise";
+import ClozeExercise, {
+  ClozeTextPart,
+  ClozeResult,
+} from "@/components/ui_elements/cloze_exercise/ClozeExercise";
 
 // Layout-Komponente mocken (wir wollen nur die Kinder rendern)
 vi.mock("@/components/layouts", () => ({
-    SubBackground: ({ children }: { children: React.ReactNode }) => (
-        <div data-testid="subbackground">{children}</div>
-    ),
+  SubBackground: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="subbackground">{children}</div>
+  ),
 }));
 
 // Helfer für DataTransfer im DnD
 function createDataTransfer(initial: Record<string, string> = {}) {
-    const store = { ...initial };
-    return {
-        setData: vi.fn((k: string, v: string) => { store[k] = v; }),
-        getData: vi.fn((k: string) => store[k]),
-        dropEffect: "move",
-        effectAllowed: "all",
-        files: [],
-        items: [],
-        types: Object.keys(store),
-    } as unknown as DataTransfer;
+  const store = { ...initial };
+  return {
+    setData: vi.fn((k: string, v: string) => {
+      store[k] = v;
+    }),
+    getData: vi.fn((k: string) => store[k]),
+    dropEffect: "move",
+    effectAllowed: "all",
+    files: [],
+    items: [],
+    types: Object.keys(store),
+  } as unknown as DataTransfer;
 }
 
 const baseText: ClozeTextPart[] = [
-    { type: "text", content: "Das" },
-    { type: "blank", correct: ["Haus"] },
-    { type: "text", content: "ist" },
-    { type: "blank", correct: ["groß", "gross"] },
-    { type: "text", content: "." },
+  { type: "text", content: "Das" },
+  { type: "blank", correct: ["Haus"] },
+  { type: "text", content: "ist" },
+  { type: "blank", correct: ["groß", "gross"] },
+  { type: "text", content: "." },
 ];
 
 describe("ClozeExercise – Input-Modus (showSolutionWords=false)", () => {
-    it("aktiviert den Submit-Button erst wenn alle Lücken gefüllt sind und ruft onSubmit nur bei korrekten Antworten", () => {
-        const onSubmit = vi.fn();
-        render(
-            <ClozeExercise
-                title="Fülle die Lücken aus:"
-                clozeText={baseText}
-                showSolutionWords={false}
-                onSubmit={onSubmit}
-            />
-        );
+  it("aktiviert den Submit-Button erst wenn alle Lücken gefüllt sind und ruft onSubmit nur bei korrekten Antworten", () => {
+    const onSubmit = vi.fn();
+    render(
+      <ClozeExercise
+        title="Fülle die Lücken aus:"
+        clozeText={baseText}
+        showSolutionWords={false}
+        onSubmit={onSubmit}
+      />,
+    );
 
-        // Button ist anfangs disabled
-        const button = screen.getByRole("button", { name: "Prüfen" });
-        expect(button).toBeDisabled();
+    // Button ist anfangs disabled
+    const button = screen.getByRole("button", { name: "Prüfen" });
+    expect(button).toBeDisabled();
 
-        // Beide Inputs befüllen (1x absichtlich falsch)
-        const inputs = screen.getAllByRole("textbox");
-        expect(inputs).toHaveLength(2);
+    // Beide Inputs befüllen (1x absichtlich falsch)
+    const inputs = screen.getAllByRole("textbox");
+    expect(inputs).toHaveLength(2);
 
-        // Erste Lücke falsch
-        fireEvent.change(inputs[0], { target: { value: "falsch" } });
-        // Zweite Lücke korrekt (case-insensitiv)
-        fireEvent.change(inputs[1], { target: { value: "GROSS" } });
+    // Erste Lücke falsch
+    fireEvent.change(inputs[0], { target: { value: "falsch" } });
+    // Zweite Lücke korrekt (case-insensitiv)
+    fireEvent.change(inputs[1], { target: { value: "GROSS" } });
 
-        // Jetzt sind alle gefüllt -> Button enabled
-        expect(button).toBeEnabled();
+    // Jetzt sind alle gefüllt -> Button enabled
+    expect(button).toBeEnabled();
 
-        // Submit (falsch + korrekt) -> Label "False", onSubmit NICHT aufgerufen
-        fireEvent.click(button);
-        expect(onSubmit).not.toHaveBeenCalled();
+    // Submit (falsch + korrekt) -> Label "False", onSubmit NICHT aufgerufen
+    fireEvent.click(button);
+    expect(onSubmit).not.toHaveBeenCalled();
 
-        // Korrigieren und erneut submitten
-        fireEvent.change(inputs[0], { target: { value: "Haus" } });
-        fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
+    // Korrigieren und erneut submitten
+    fireEvent.change(inputs[0], { target: { value: "Haus" } });
+    fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
 
-        expect(onSubmit).toHaveBeenCalledTimes(1);
-    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("ClozeExercise – Drag&Drop-Modus (showSolutionWords=true)", () => {
-    beforeEach(() => {
-        vi.useRealTimers();
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("füllt Lücken via QuickPlace (Ctrl/Cmd-Klick)", () => {
+    const onSubmit = vi.fn();
+    render(
+      <ClozeExercise
+        clozeText={baseText}
+        showSolutionWords={true}
+        wrongSolutionWords={["Baum"]}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    // Wordbank vorhanden, enthält mindestens die beiden korrekten Erstlösungen + evtl. falsches Wort
+    const bank = screen.getByTestId("solution-words");
+    const wordHaus = screen.getByText("Haus");
+    const wordGross = screen.getByText("groß"); // aus correct[0] (falls es "groß" ist)
+    expect(bank).toBeInTheDocument();
+    expect(wordHaus).toBeInTheDocument();
+    expect(wordGross).toBeInTheDocument();
+
+    // QuickPlace: Ctrl-Klick auf "Haus" -> füllt erste freie Lücke
+    fireEvent.click(wordHaus, { ctrlKey: true });
+
+    const blank1 = screen.getByTestId("blank-1");
+    const blank3 = screen.getByTestId("blank-3");
+    expect(blank1).toHaveTextContent("Haus");
+
+    // Zweites Wort via Drag & Drop in zweite Lücke
+    const dtCapture = createDataTransfer();
+    // dragStart am Bank-Wort triggert setData("wordId", "<id>")
+    fireEvent.dragStart(wordGross, { dataTransfer: dtCapture });
+    const setDataCall = (dtCapture.setData as unknown as any).mock.calls.find(
+      (c: any[]) => c[0] === "wordId",
+    );
+    expect(setDataCall, "dragStart sollte wordId setzen").toBeTruthy();
+    const grossId = setDataCall[1] as string;
+
+    // Jetzt den Drop mit dieser ID auf die zweite Lücke ausführen
+    const dtDrop = createDataTransfer({ wordId: grossId });
+    fireEvent.dragOver(blank3, { dataTransfer: dtDrop });
+    fireEvent.drop(blank3, { dataTransfer: dtDrop });
+
+    // Beide Lücken sollten belegt sein
+    expect(blank1).toHaveTextContent("Haus");
+    expect(blank3).toHaveTextContent("groß");
+
+    // Button aktiv -> Submit -> True & onSubmit aufgerufen
+    const button = screen.getByRole("button", { name: "Prüfen" });
+    expect(button).toBeEnabled();
+    fireEvent.click(button);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("Rückgabe in die Wordbank (Drop auf Bank) räumt die Lücke wieder leer", () => {
+    render(
+      <ClozeExercise
+        clozeText={baseText}
+        showSolutionWords={true}
+        wrongSolutionWords={[]}
+        onSubmit={() => {}}
+      />,
+    );
+
+    const bank = screen.getByTestId("solution-words");
+    const wordHaus = screen.getByTestId("wordbank-0");
+
+    // Erst in erste Lücke packen (QuickPlace)
+    fireEvent.click(wordHaus, { ctrlKey: true });
+    const blank = screen.getByTestId("blank-1");
+    expect(blank).toHaveTextContent("Haus");
+
+    // Dann per Drop zurück in die Bank
+    const word = within(blank).getByText("Haus");
+    const dtCapture = createDataTransfer();
+    fireEvent.dragStart(word, { dataTransfer: dtCapture });
+    const setDataCall = (dtCapture.setData as unknown as any).mock.calls.find(
+      (c: any[]) => c[0] === "wordId",
+    );
+    const id = setDataCall?.[1] as string;
+
+    const dtDropBack = createDataTransfer({ wordId: id });
+    fireEvent.dragOver(bank, { dataTransfer: dtDropBack });
+    fireEvent.drop(bank, { dataTransfer: dtDropBack });
+
+    expect(blank).toHaveTextContent("");
+  });
+
+  it("Ctrl/Cmd-Klick auf belegte Lücke: Wort wird aus der Lücke entfernt und in der Wordbank wieder verfügbar", () => {
+    render(
+      <ClozeExercise
+        clozeText={baseText}
+        showSolutionWords={true}
+        wrongSolutionWords={[]}
+        onSubmit={() => {}}
+      />,
+    );
+    const wordHaus = screen.getByTestId("wordbank-0");
+
+    // 1) QuickPlace: 'Haus' in die erste Lücke setzen
+    fireEvent.click(wordHaus, { ctrlKey: true });
+    const blank = screen.getByTestId("blank-1");
+    expect(blank).toHaveTextContent("Haus");
+
+    // In der Bank sollte 'Haus' jetzt nicht mehr draggable sein
+    expect(screen.getByTestId("wordbank-0")).toHaveAttribute(
+      "draggable",
+      "false",
+    );
+
+    // 2) Ctrl-Klick auf die belegte Lücke => leeren
+    fireEvent.click(blank, { ctrlKey: true });
+
+    // Lücke wieder leer
+    expect(blank).toHaveTextContent("");
+
+    // 3) In der Bank ist 'Haus' wieder verfügbar (draggable=true)
+    const hausInBank = screen.getByTestId("wordbank-0");
+    expect(hausInBank).toHaveAttribute("draggable", "true");
+  });
+
+  describe("ClozeExercise – Feedback-Anzeige", () => {
+    it("zeigt ein Fehler-Feedback, wenn nicht alle Antworten korrekt sind", async () => {
+      const onSubmit = vi.fn();
+      render(
+        <ClozeExercise
+          clozeText={baseText}
+          showSolutionWords={false}
+          onSubmit={onSubmit}
+        />,
+      );
+
+      // Vorher kein Feedback
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+
+      // 1x falsch, 1x richtig
+      const inputs = screen.getAllByRole("textbox");
+      fireEvent.change(inputs[0], { target: { value: "falsch" } });
+      fireEvent.change(inputs[1], { target: { value: "GROSS" } });
+
+      // Prüfen
+      fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
+
+      // onSubmit nicht aufgerufen, Fehlermeldung sichtbar
+      expect(onSubmit).not.toHaveBeenCalled();
+      const status = await screen.findByRole("status");
+      expect(status).toBeInTheDocument();
+      expect(status).toHaveTextContent(/Noch nicht ganz:/i);
+      expect(status).toHaveTextContent(/1\s+von\s+2/i);
+      // Stilklasse für Fehler (aus der Komponente)
+      expect(status).toHaveClass("bg-red-50");
     });
 
-    it("füllt Lücken via QuickPlace (Ctrl/Cmd-Klick)", () => {
-        const onSubmit = vi.fn();
-        render(
-            <ClozeExercise
-                clozeText={baseText}
-                showSolutionWords={true}
-                wrongSolutionWords={["Baum"]}
-                onSubmit={onSubmit}
-            />
-        );
+    it("zeigt ein Erfolgs-Feedback, wenn alle Antworten korrekt sind", async () => {
+      const onSubmit = vi.fn();
+      render(
+        <ClozeExercise
+          clozeText={baseText}
+          showSolutionWords={false}
+          onSubmit={onSubmit}
+        />,
+      );
 
-        // Wordbank vorhanden, enthält mindestens die beiden korrekten Erstlösungen + evtl. falsches Wort
-        const bank = screen.getByTestId("solution-words");
-        const wordHaus = screen.getByText("Haus");
-        const wordGross = screen.getByText("groß"); // aus correct[0] (falls es "groß" ist)
-        expect(bank).toBeInTheDocument();
-        expect(wordHaus).toBeInTheDocument();
-        expect(wordGross).toBeInTheDocument();
+      // Alles korrekt befüllen
+      const inputs = screen.getAllByRole("textbox");
+      fireEvent.change(inputs[0], { target: { value: "Haus" } });
+      fireEvent.change(inputs[1], { target: { value: "gross" } }); // erlaubt per correct[] Alternative
 
-        // QuickPlace: Ctrl-Klick auf "Haus" -> füllt erste freie Lücke
-        fireEvent.click(wordHaus, { ctrlKey: true });
+      // Prüfen
+      fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
 
-        const blank1 = screen.getByTestId("blank-1");
-        const blank3 = screen.getByTestId("blank-3");
-        expect(blank1).toHaveTextContent("Haus");
-
-        // Zweites Wort via Drag & Drop in zweite Lücke
-        const dtCapture = createDataTransfer();
-        // dragStart am Bank-Wort triggert setData("wordId", "<id>")
-        fireEvent.dragStart(wordGross, { dataTransfer: dtCapture });
-        const setDataCall = (dtCapture.setData as unknown as any).mock.calls.find(
-            (c: any[]) => c[0] === "wordId"
-        );
-        expect(setDataCall, "dragStart sollte wordId setzen").toBeTruthy();
-        const grossId = setDataCall[1] as string;
-
-        // Jetzt den Drop mit dieser ID auf die zweite Lücke ausführen
-        const dtDrop = createDataTransfer({ wordId: grossId });
-        fireEvent.dragOver(blank3, { dataTransfer: dtDrop });
-        fireEvent.drop(blank3, { dataTransfer: dtDrop });
-
-        // Beide Lücken sollten belegt sein
-        expect(blank1).toHaveTextContent("Haus");
-        expect(blank3).toHaveTextContent("groß");
-
-        // Button aktiv -> Submit -> True & onSubmit aufgerufen
-        const button = screen.getByRole("button", { name: "Prüfen" });
-        expect(button).toBeEnabled();
-        fireEvent.click(button);
-        expect(onSubmit).toHaveBeenCalledTimes(1);
+      // onSubmit aufgerufen, Erfolgsfeedback sichtbar
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      const status = await screen.findByRole("status");
+      expect(status).toBeInTheDocument();
+      expect(status).toHaveTextContent(/Alles richtig! Super gemacht!/i);
+      // Stilklasse für Erfolg (aus der Komponente)
+      expect(status).toHaveClass("bg-green-50");
     });
-
-    it("Rückgabe in die Wordbank (Drop auf Bank) räumt die Lücke wieder leer", () => {
-        render(
-            <ClozeExercise
-                clozeText={baseText}
-                showSolutionWords={true}
-                wrongSolutionWords={[]}
-                onSubmit={() => { }}
-            />
-        );
-
-        const bank = screen.getByTestId("solution-words");
-        const wordHaus = screen.getByTestId("wordbank-0");
-
-        // Erst in erste Lücke packen (QuickPlace)
-        fireEvent.click(wordHaus, { ctrlKey: true });
-        const blank = screen.getByTestId("blank-1");
-        expect(blank).toHaveTextContent("Haus");
-
-        // Dann per Drop zurück in die Bank
-        const word = within(blank).getByText("Haus");
-        const dtCapture = createDataTransfer();
-        fireEvent.dragStart(word, { dataTransfer: dtCapture });
-        const setDataCall = (dtCapture.setData as unknown as any).mock.calls.find(
-            (c: any[]) => c[0] === "wordId"
-        );
-        const id = setDataCall?.[1] as string;
-
-        const dtDropBack = createDataTransfer({ wordId: id });
-        fireEvent.dragOver(bank, { dataTransfer: dtDropBack });
-        fireEvent.drop(bank, { dataTransfer: dtDropBack });
-
-        expect(blank).toHaveTextContent("");
-    });
-
-    it("Ctrl/Cmd-Klick auf belegte Lücke: Wort wird aus der Lücke entfernt und in der Wordbank wieder verfügbar", () => {
-        render(
-            <ClozeExercise
-                clozeText={baseText}
-                showSolutionWords={true}
-                wrongSolutionWords={[]}
-                onSubmit={() => { }}
-            />
-        );
-        const wordHaus = screen.getByTestId("wordbank-0");
-
-        // 1) QuickPlace: 'Haus' in die erste Lücke setzen
-        fireEvent.click(wordHaus, { ctrlKey: true });
-        const blank = screen.getByTestId("blank-1");
-        expect(blank).toHaveTextContent("Haus");
-
-        // In der Bank sollte 'Haus' jetzt nicht mehr draggable sein
-        expect(screen.getByTestId("wordbank-0")).toHaveAttribute("draggable", "false");
-
-        // 2) Ctrl-Klick auf die belegte Lücke => leeren
-        fireEvent.click(blank, { ctrlKey: true });
-
-        // Lücke wieder leer
-        expect(blank).toHaveTextContent("");
-
-        // 3) In der Bank ist 'Haus' wieder verfügbar (draggable=true)
-        const hausInBank = screen.getByTestId("wordbank-0");
-        expect(hausInBank).toHaveAttribute("draggable", "true");
-    });
-
-    describe("ClozeExercise – Feedback-Anzeige", () => {
-        it("zeigt ein Fehler-Feedback, wenn nicht alle Antworten korrekt sind", async () => {
-            const onSubmit = vi.fn();
-            render(
-                <ClozeExercise
-                    clozeText={baseText}
-                    showSolutionWords={false}
-                    onSubmit={onSubmit}
-                />
-            );
-
-            // Vorher kein Feedback
-            expect(screen.queryByRole("status")).not.toBeInTheDocument();
-
-            // 1x falsch, 1x richtig
-            const inputs = screen.getAllByRole("textbox");
-            fireEvent.change(inputs[0], { target: { value: "falsch" } });
-            fireEvent.change(inputs[1], { target: { value: "GROSS" } });
-
-            // Prüfen
-            fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
-
-            // onSubmit nicht aufgerufen, Fehlermeldung sichtbar
-            expect(onSubmit).not.toHaveBeenCalled();
-            const status = await screen.findByRole("status");
-            expect(status).toBeInTheDocument();
-            expect(status).toHaveTextContent(/Noch nicht ganz:/i);
-            expect(status).toHaveTextContent(/1\s+von\s+2/i);
-            // Stilklasse für Fehler (aus der Komponente)
-            expect(status).toHaveClass("bg-red-50");
-        });
-
-        it("zeigt ein Erfolgs-Feedback, wenn alle Antworten korrekt sind", async () => {
-            const onSubmit = vi.fn();
-            render(
-                <ClozeExercise
-                    clozeText={baseText}
-                    showSolutionWords={false}
-                    onSubmit={onSubmit}
-                />
-            );
-
-            // Alles korrekt befüllen
-            const inputs = screen.getAllByRole("textbox");
-            fireEvent.change(inputs[0], { target: { value: "Haus" } });
-            fireEvent.change(inputs[1], { target: { value: "gross" } }); // erlaubt per correct[] Alternative
-
-            // Prüfen
-            fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
-
-            // onSubmit aufgerufen, Erfolgsfeedback sichtbar
-            expect(onSubmit).toHaveBeenCalledTimes(1);
-            const status = await screen.findByRole("status");
-            expect(status).toBeInTheDocument();
-            expect(status).toHaveTextContent(/Alles richtig! Super gemacht!/i);
-            // Stilklasse für Erfolg (aus der Komponente)
-            expect(status).toHaveClass("bg-green-50");
-        });
-    });
+  });
 });

--- a/frontend/tests/components/cloze-exercise/ClozeExercise.test.tsx
+++ b/frontend/tests/components/cloze-exercise/ClozeExercise.test.tsx
@@ -2,195 +2,203 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import React from "react";
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
-import ClozeExercise, { ClozeTextPart, ClozeResult } from "@/components/ui_elements/cloze_exercise/ClozeExercise";
+import ClozeExercise, {
+  ClozeTextPart,
+  ClozeResult,
+} from "@/components/ui_elements/cloze_exercise/ClozeExercise";
 
 // Layout-Komponente mocken (wir wollen nur die Kinder rendern)
 vi.mock("@/components/layouts", () => ({
-    SubBackground: ({ children }: { children: React.ReactNode }) => (
-        <div data-testid="subbackground">{children}</div>
-    ),
+  SubBackground: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="subbackground">{children}</div>
+  ),
 }));
 
 // Helfer für DataTransfer im DnD
 function createDataTransfer(initial: Record<string, string> = {}) {
-    const store = { ...initial };
-    return {
-        setData: vi.fn((k: string, v: string) => { store[k] = v; }),
-        getData: vi.fn((k: string) => store[k]),
-        dropEffect: "move",
-        effectAllowed: "all",
-        files: [],
-        items: [],
-        types: Object.keys(store),
-    } as unknown as DataTransfer;
+  const store = { ...initial };
+  return {
+    setData: vi.fn((k: string, v: string) => {
+      store[k] = v;
+    }),
+    getData: vi.fn((k: string) => store[k]),
+    dropEffect: "move",
+    effectAllowed: "all",
+    files: [],
+    items: [],
+    types: Object.keys(store),
+  } as unknown as DataTransfer;
 }
 
 const baseText: ClozeTextPart[] = [
-    { type: "text", content: "Das" },
-    { type: "blank", correct: ["Haus"] },
-    { type: "text", content: "ist" },
-    { type: "blank", correct: ["groß", "gross"] },
-    { type: "text", content: "." },
+  { type: "text", content: "Das" },
+  { type: "blank", correct: ["Haus"] },
+  { type: "text", content: "ist" },
+  { type: "blank", correct: ["groß", "gross"] },
+  { type: "text", content: "." },
 ];
 
 describe("ClozeExercise – Input-Modus (showSolutionWords=false)", () => {
-    it("aktiviert den Submit-Button erst wenn alle Lücken gefüllt sind und ruft onSubmit nur bei korrekten Antworten", () => {
-        const onSubmit = vi.fn();
-        render(
-            <ClozeExercise
-                title="Fülle die Lücken aus:"
-                clozeText={baseText}
-                showSolutionWords={false}
-                onSubmit={onSubmit}
-            />
-        );
+  it("aktiviert den Submit-Button erst wenn alle Lücken gefüllt sind und ruft onSubmit nur bei korrekten Antworten", () => {
+    const onSubmit = vi.fn();
+    render(
+      <ClozeExercise
+        title="Fülle die Lücken aus:"
+        clozeText={baseText}
+        showSolutionWords={false}
+        onSubmit={onSubmit}
+      />,
+    );
 
-        // Button ist anfangs disabled
-        const button = screen.getByRole("button", { name: "Prüfen" });
-        expect(button).toBeDisabled();
+    // Button ist anfangs disabled
+    const button = screen.getByRole("button", { name: "Prüfen" });
+    expect(button).toBeDisabled();
 
-        // Beide Inputs befüllen (1x absichtlich falsch)
-        const inputs = screen.getAllByRole("textbox");
-        expect(inputs).toHaveLength(2);
+    // Beide Inputs befüllen (1x absichtlich falsch)
+    const inputs = screen.getAllByRole("textbox");
+    expect(inputs).toHaveLength(2);
 
-        // Erste Lücke falsch
-        fireEvent.change(inputs[0], { target: { value: "falsch" } });
-        // Zweite Lücke korrekt (case-insensitiv)
-        fireEvent.change(inputs[1], { target: { value: "GROSS" } });
+    // Erste Lücke falsch
+    fireEvent.change(inputs[0], { target: { value: "falsch" } });
+    // Zweite Lücke korrekt (case-insensitiv)
+    fireEvent.change(inputs[1], { target: { value: "GROSS" } });
 
-        // Jetzt sind alle gefüllt -> Button enabled
-        expect(button).toBeEnabled();
+    // Jetzt sind alle gefüllt -> Button enabled
+    expect(button).toBeEnabled();
 
-        // Submit (falsch + korrekt) -> Label "False", onSubmit NICHT aufgerufen
-        fireEvent.click(button);
-        expect(onSubmit).not.toHaveBeenCalled();
+    // Submit (falsch + korrekt) -> Label "False", onSubmit NICHT aufgerufen
+    fireEvent.click(button);
+    expect(onSubmit).not.toHaveBeenCalled();
 
-        // Korrigieren und erneut submitten
-        fireEvent.change(inputs[0], { target: { value: "Haus" } });
-        fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
+    // Korrigieren und erneut submitten
+    fireEvent.change(inputs[0], { target: { value: "Haus" } });
+    fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
 
-        expect(onSubmit).toHaveBeenCalledTimes(1);
-    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("ClozeExercise – Drag&Drop-Modus (showSolutionWords=true)", () => {
-    beforeEach(() => {
-        vi.useRealTimers();
-    });
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
 
-    it("füllt Lücken via QuickPlace (Ctrl/Cmd-Klick)", () => {
-        const onSubmit = vi.fn();
-        render(
-            <ClozeExercise
-                clozeText={baseText}
-                showSolutionWords={true}
-                wrongSolutionWords={["Baum"]}
-                onSubmit={onSubmit}
-            />
-        );
+  it("füllt Lücken via QuickPlace (Ctrl/Cmd-Klick)", () => {
+    const onSubmit = vi.fn();
+    render(
+      <ClozeExercise
+        clozeText={baseText}
+        showSolutionWords={true}
+        wrongSolutionWords={["Baum"]}
+        onSubmit={onSubmit}
+      />,
+    );
 
-        // Wordbank vorhanden, enthält mindestens die beiden korrekten Erstlösungen + evtl. falsches Wort
-        const bank = screen.getByTestId("solution-words");
-        const wordHaus = screen.getByText("Haus");
-        const wordGross = screen.getByText("groß"); // aus correct[0] (falls es "groß" ist)
-        expect(bank).toBeInTheDocument();
-        expect(wordHaus).toBeInTheDocument();
-        expect(wordGross).toBeInTheDocument();
+    // Wordbank vorhanden, enthält mindestens die beiden korrekten Erstlösungen + evtl. falsches Wort
+    const bank = screen.getByTestId("solution-words");
+    const wordHaus = screen.getByText("Haus");
+    const wordGross = screen.getByText("groß"); // aus correct[0] (falls es "groß" ist)
+    expect(bank).toBeInTheDocument();
+    expect(wordHaus).toBeInTheDocument();
+    expect(wordGross).toBeInTheDocument();
 
-        // QuickPlace: Ctrl-Klick auf "Haus" -> füllt erste freie Lücke
-        fireEvent.click(wordHaus, { ctrlKey: true });
+    // QuickPlace: Ctrl-Klick auf "Haus" -> füllt erste freie Lücke
+    fireEvent.click(wordHaus, { ctrlKey: true });
 
-        const blank1 = screen.getByTestId("blank-1");
-        const blank3 = screen.getByTestId("blank-3");
-        expect(blank1).toHaveTextContent("Haus");
+    const blank1 = screen.getByTestId("blank-1");
+    const blank3 = screen.getByTestId("blank-3");
+    expect(blank1).toHaveTextContent("Haus");
 
-        // Zweites Wort via Drag & Drop in zweite Lücke
-        const dtCapture = createDataTransfer();
-        // dragStart am Bank-Wort triggert setData("wordId", "<id>")
-        fireEvent.dragStart(wordGross, { dataTransfer: dtCapture });
-        const setDataCall = (dtCapture.setData as unknown as any).mock.calls.find(
-            (c: any[]) => c[0] === "wordId"
-        );
-        expect(setDataCall, "dragStart sollte wordId setzen").toBeTruthy();
-        const grossId = setDataCall[1] as string;
+    // Zweites Wort via Drag & Drop in zweite Lücke
+    const dtCapture = createDataTransfer();
+    // dragStart am Bank-Wort triggert setData("wordId", "<id>")
+    fireEvent.dragStart(wordGross, { dataTransfer: dtCapture });
+    const setDataCall = (dtCapture.setData as unknown as any).mock.calls.find(
+      (c: any[]) => c[0] === "wordId",
+    );
+    expect(setDataCall, "dragStart sollte wordId setzen").toBeTruthy();
+    const grossId = setDataCall[1] as string;
 
-        // Jetzt den Drop mit dieser ID auf die zweite Lücke ausführen
-        const dtDrop = createDataTransfer({ wordId: grossId });
-        fireEvent.dragOver(blank3, { dataTransfer: dtDrop });
-        fireEvent.drop(blank3, { dataTransfer: dtDrop });
+    // Jetzt den Drop mit dieser ID auf die zweite Lücke ausführen
+    const dtDrop = createDataTransfer({ wordId: grossId });
+    fireEvent.dragOver(blank3, { dataTransfer: dtDrop });
+    fireEvent.drop(blank3, { dataTransfer: dtDrop });
 
-        // Beide Lücken sollten belegt sein
-        expect(blank1).toHaveTextContent("Haus");
-        expect(blank3).toHaveTextContent("groß");
+    // Beide Lücken sollten belegt sein
+    expect(blank1).toHaveTextContent("Haus");
+    expect(blank3).toHaveTextContent("groß");
 
-        // Button aktiv -> Submit -> True & onSubmit aufgerufen
-        const button = screen.getByRole("button", { name: "Prüfen" });
-        expect(button).toBeEnabled();
-        fireEvent.click(button);
-        expect(onSubmit).toHaveBeenCalledTimes(1);
-    });
+    // Button aktiv -> Submit -> True & onSubmit aufgerufen
+    const button = screen.getByRole("button", { name: "Prüfen" });
+    expect(button).toBeEnabled();
+    fireEvent.click(button);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
 
-    it("Rückgabe in die Wordbank (Drop auf Bank) räumt die Lücke wieder leer", () => {
-        render(
-            <ClozeExercise
-                clozeText={baseText}
-                showSolutionWords={true}
-                wrongSolutionWords={[]}
-                onSubmit={() => { }}
-            />
-        );
+  it("Rückgabe in die Wordbank (Drop auf Bank) räumt die Lücke wieder leer", () => {
+    render(
+      <ClozeExercise
+        clozeText={baseText}
+        showSolutionWords={true}
+        wrongSolutionWords={[]}
+        onSubmit={() => {}}
+      />,
+    );
 
-        const bank = screen.getByTestId("solution-words");
-        const wordHaus = screen.getByTestId("wordbank-0");
+    const bank = screen.getByTestId("solution-words");
+    const wordHaus = screen.getByTestId("wordbank-0");
 
-        // Erst in erste Lücke packen (QuickPlace)
-        fireEvent.click(wordHaus, { ctrlKey: true });
-        const blank = screen.getByTestId("blank-1");
-        expect(blank).toHaveTextContent("Haus");
+    // Erst in erste Lücke packen (QuickPlace)
+    fireEvent.click(wordHaus, { ctrlKey: true });
+    const blank = screen.getByTestId("blank-1");
+    expect(blank).toHaveTextContent("Haus");
 
-        // Dann per Drop zurück in die Bank
-        const word = within(blank).getByText("Haus");
-        const dtCapture = createDataTransfer();
-        fireEvent.dragStart(word, { dataTransfer: dtCapture });
-        const setDataCall = (dtCapture.setData as unknown as any).mock.calls.find(
-            (c: any[]) => c[0] === "wordId"
-        );
-        const id = setDataCall?.[1] as string;
+    // Dann per Drop zurück in die Bank
+    const word = within(blank).getByText("Haus");
+    const dtCapture = createDataTransfer();
+    fireEvent.dragStart(word, { dataTransfer: dtCapture });
+    const setDataCall = (dtCapture.setData as unknown as any).mock.calls.find(
+      (c: any[]) => c[0] === "wordId",
+    );
+    const id = setDataCall?.[1] as string;
 
-        const dtDropBack = createDataTransfer({ wordId: id });
-        fireEvent.dragOver(bank, { dataTransfer: dtDropBack });
-        fireEvent.drop(bank, { dataTransfer: dtDropBack });
+    const dtDropBack = createDataTransfer({ wordId: id });
+    fireEvent.dragOver(bank, { dataTransfer: dtDropBack });
+    fireEvent.drop(bank, { dataTransfer: dtDropBack });
 
-        expect(blank).toHaveTextContent("");
-    });
+    expect(blank).toHaveTextContent("");
+  });
 
-    it("Ctrl/Cmd-Klick auf belegte Lücke: Wort wird aus der Lücke entfernt und in der Wordbank wieder verfügbar", () => {
-        render(
-            <ClozeExercise
-                clozeText={baseText}
-                showSolutionWords={true}
-                wrongSolutionWords={[]}
-                onSubmit={() => { }}
-            />
-        );
-        const wordHaus = screen.getByTestId("wordbank-0");
+  it("Ctrl/Cmd-Klick auf belegte Lücke: Wort wird aus der Lücke entfernt und in der Wordbank wieder verfügbar", () => {
+    render(
+      <ClozeExercise
+        clozeText={baseText}
+        showSolutionWords={true}
+        wrongSolutionWords={[]}
+        onSubmit={() => {}}
+      />,
+    );
+    const wordHaus = screen.getByTestId("wordbank-0");
 
-        // 1) QuickPlace: 'Haus' in die erste Lücke setzen
-        fireEvent.click(wordHaus, { ctrlKey: true });
-        const blank = screen.getByTestId("blank-1");
-        expect(blank).toHaveTextContent("Haus");
+    // 1) QuickPlace: 'Haus' in die erste Lücke setzen
+    fireEvent.click(wordHaus, { ctrlKey: true });
+    const blank = screen.getByTestId("blank-1");
+    expect(blank).toHaveTextContent("Haus");
 
-        // In der Bank sollte 'Haus' jetzt nicht mehr draggable sein
-        expect(screen.getByTestId("wordbank-0")).toHaveAttribute("draggable", "false");
+    // In der Bank sollte 'Haus' jetzt nicht mehr draggable sein
+    expect(screen.getByTestId("wordbank-0")).toHaveAttribute(
+      "draggable",
+      "false",
+    );
 
-        // 2) Ctrl-Klick auf die belegte Lücke => leeren
-        fireEvent.click(blank, { ctrlKey: true });
+    // 2) Ctrl-Klick auf die belegte Lücke => leeren
+    fireEvent.click(blank, { ctrlKey: true });
 
-        // Lücke wieder leer
-        expect(blank).toHaveTextContent("");
+    // Lücke wieder leer
+    expect(blank).toHaveTextContent("");
 
-        // 3) In der Bank ist 'Haus' wieder verfügbar (draggable=true)
-        const hausInBank = screen.getByTestId("wordbank-0");
-        expect(hausInBank).toHaveAttribute("draggable", "true");
-    });
+    // 3) In der Bank ist 'Haus' wieder verfügbar (draggable=true)
+    const hausInBank = screen.getByTestId("wordbank-0");
+    expect(hausInBank).toHaveAttribute("draggable", "true");
+  });
 });

--- a/frontend/tests/components/cloze-exercise/ClozeExercise.test.tsx
+++ b/frontend/tests/components/cloze-exercise/ClozeExercise.test.tsx
@@ -3,262 +3,262 @@ import React from "react";
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import ClozeExercise, {
-    ClozeTextPart,
-    ClozeResult,
+  ClozeTextPart,
+  ClozeResult,
 } from "@/components/ui_elements/cloze_exercise/ClozeExercise";
 
 // Layout-Komponente mocken (wir wollen nur die Kinder rendern)
 vi.mock("@/components/layouts", () => ({
-    SubBackground: ({ children }: { children: React.ReactNode }) => (
-        <div data-testid="subbackground">{children}</div>
-    ),
+  SubBackground: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="subbackground">{children}</div>
+  ),
 }));
 
 // Helfer für DataTransfer im DnD
 function createDataTransfer(initial: Record<string, string> = {}) {
-    const store = { ...initial };
-    return {
-        setData: vi.fn((k: string, v: string) => {
-            store[k] = v;
-        }),
-        getData: vi.fn((k: string) => store[k]),
-        dropEffect: "move",
-        effectAllowed: "all",
-        files: [],
-        items: [],
-        types: Object.keys(store),
-    } as unknown as DataTransfer;
+  const store = { ...initial };
+  return {
+    setData: vi.fn((k: string, v: string) => {
+      store[k] = v;
+    }),
+    getData: vi.fn((k: string) => store[k]),
+    dropEffect: "move",
+    effectAllowed: "all",
+    files: [],
+    items: [],
+    types: Object.keys(store),
+  } as unknown as DataTransfer;
 }
 
 const baseText: ClozeTextPart[] = [
-    { type: "text", content: "Das" },
-    { type: "blank", correct: ["Haus"] },
-    { type: "text", content: "ist" },
-    { type: "blank", correct: ["groß", "gross"] },
-    { type: "text", content: "." },
+  { type: "text", content: "Das" },
+  { type: "blank", correct: ["Haus"] },
+  { type: "text", content: "ist" },
+  { type: "blank", correct: ["groß", "gross"] },
+  { type: "text", content: "." },
 ];
 
 describe("ClozeExercise – Input-Modus (showSolutionWords=false)", () => {
-    it("aktiviert den Submit-Button erst wenn alle Lücken gefüllt sind und ruft onSubmit nur bei korrekten Antworten", () => {
-        const onSubmit = vi.fn();
-        render(
-            <ClozeExercise
-                title="Fülle die Lücken aus:"
-                clozeText={baseText}
-                showSolutionWords={false}
-                onSubmit={onSubmit}
-            />,
-        );
+  it("aktiviert den Submit-Button erst wenn alle Lücken gefüllt sind und ruft onSubmit nur bei korrekten Antworten", () => {
+    const onSubmit = vi.fn();
+    render(
+      <ClozeExercise
+        title="Fülle die Lücken aus:"
+        clozeText={baseText}
+        showSolutionWords={false}
+        onSubmit={onSubmit}
+      />,
+    );
 
-        // Button ist anfangs disabled
-        const button = screen.getByRole("button", { name: "Prüfen" });
-        expect(button).toBeDisabled();
+    // Button ist anfangs disabled
+    const button = screen.getByRole("button", { name: "Prüfen" });
+    expect(button).toBeDisabled();
 
-        // Beide Inputs befüllen (1x absichtlich falsch)
-        const inputs = screen.getAllByRole("textbox");
-        expect(inputs).toHaveLength(2);
+    // Beide Inputs befüllen (1x absichtlich falsch)
+    const inputs = screen.getAllByRole("textbox");
+    expect(inputs).toHaveLength(2);
 
-        // Erste Lücke falsch
-        fireEvent.change(inputs[0], { target: { value: "falsch" } });
-        // Zweite Lücke korrekt (case-insensitiv)
-        fireEvent.change(inputs[1], { target: { value: "GROSS" } });
+    // Erste Lücke falsch
+    fireEvent.change(inputs[0], { target: { value: "falsch" } });
+    // Zweite Lücke korrekt (case-insensitiv)
+    fireEvent.change(inputs[1], { target: { value: "GROSS" } });
 
-        // Jetzt sind alle gefüllt -> Button enabled
-        expect(button).toBeEnabled();
+    // Jetzt sind alle gefüllt -> Button enabled
+    expect(button).toBeEnabled();
 
-        // Submit (falsch + korrekt) -> Label "False", onSubmit NICHT aufgerufen
-        fireEvent.click(button);
-        expect(onSubmit).not.toHaveBeenCalled();
+    // Submit (falsch + korrekt) -> Label "False", onSubmit NICHT aufgerufen
+    fireEvent.click(button);
+    expect(onSubmit).not.toHaveBeenCalled();
 
-        // Korrigieren und erneut submitten
-        fireEvent.change(inputs[0], { target: { value: "Haus" } });
-        fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
+    // Korrigieren und erneut submitten
+    fireEvent.change(inputs[0], { target: { value: "Haus" } });
+    fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
 
-        expect(onSubmit).toHaveBeenCalledTimes(1);
-    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("ClozeExercise – Drag&Drop-Modus (showSolutionWords=true)", () => {
-    beforeEach(() => {
-        vi.useRealTimers();
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("füllt Lücken via QuickPlace (Ctrl/Cmd-Klick)", () => {
+    const onSubmit = vi.fn();
+    render(
+      <ClozeExercise
+        clozeText={baseText}
+        showSolutionWords={true}
+        wrongSolutionWords={["Baum"]}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    // Wordbank vorhanden, enthält mindestens die beiden korrekten Erstlösungen + evtl. falsches Wort
+    const bank = screen.getByTestId("solution-words");
+    const wordHaus = screen.getByText("Haus");
+    const wordGross = screen.getByText("groß"); // aus correct[0] (falls es "groß" ist)
+    expect(bank).toBeInTheDocument();
+    expect(wordHaus).toBeInTheDocument();
+    expect(wordGross).toBeInTheDocument();
+
+    // QuickPlace: Ctrl-Klick auf "Haus" -> füllt erste freie Lücke
+    fireEvent.click(wordHaus, { ctrlKey: true });
+
+    const blank1 = screen.getByTestId("blank-1");
+    const blank3 = screen.getByTestId("blank-3");
+    expect(blank1).toHaveTextContent("Haus");
+
+    // Zweites Wort via Drag & Drop in zweite Lücke
+    const dtCapture = createDataTransfer();
+    // dragStart am Bank-Wort triggert setData("wordId", "<id>")
+    fireEvent.dragStart(wordGross, { dataTransfer: dtCapture });
+    const setDataCall = (dtCapture.setData as unknown as any).mock.calls.find(
+      (c: any[]) => c[0] === "wordId",
+    );
+    expect(setDataCall, "dragStart sollte wordId setzen").toBeTruthy();
+    const grossId = setDataCall[1] as string;
+
+    // Jetzt den Drop mit dieser ID auf die zweite Lücke ausführen
+    const dtDrop = createDataTransfer({ wordId: grossId });
+    fireEvent.dragOver(blank3, { dataTransfer: dtDrop });
+    fireEvent.drop(blank3, { dataTransfer: dtDrop });
+
+    // Beide Lücken sollten belegt sein
+    expect(blank1).toHaveTextContent("Haus");
+    expect(blank3).toHaveTextContent("groß");
+
+    // Button aktiv -> Submit -> True & onSubmit aufgerufen
+    const button = screen.getByRole("button", { name: "Prüfen" });
+    expect(button).toBeEnabled();
+    fireEvent.click(button);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("Rückgabe in die Wordbank (Drop auf Bank) räumt die Lücke wieder leer", () => {
+    render(
+      <ClozeExercise
+        clozeText={baseText}
+        showSolutionWords={true}
+        wrongSolutionWords={[]}
+        onSubmit={() => {}}
+      />,
+    );
+
+    const bank = screen.getByTestId("solution-words");
+    const wordHaus = screen.getByTestId("wordbank-0");
+
+    // Erst in erste Lücke packen (QuickPlace)
+    fireEvent.click(wordHaus, { ctrlKey: true });
+    const blank = screen.getByTestId("blank-1");
+    expect(blank).toHaveTextContent("Haus");
+
+    // Dann per Drop zurück in die Bank
+    const word = within(blank).getByText("Haus");
+    const dtCapture = createDataTransfer();
+    fireEvent.dragStart(word, { dataTransfer: dtCapture });
+    const setDataCall = (dtCapture.setData as unknown as any).mock.calls.find(
+      (c: any[]) => c[0] === "wordId",
+    );
+    const id = setDataCall?.[1] as string;
+
+    const dtDropBack = createDataTransfer({ wordId: id });
+    fireEvent.dragOver(bank, { dataTransfer: dtDropBack });
+    fireEvent.drop(bank, { dataTransfer: dtDropBack });
+
+    expect(blank).toHaveTextContent("");
+  });
+
+  it("Ctrl/Cmd-Klick auf belegte Lücke: Wort wird aus der Lücke entfernt und in der Wordbank wieder verfügbar", () => {
+    render(
+      <ClozeExercise
+        clozeText={baseText}
+        showSolutionWords={true}
+        wrongSolutionWords={[]}
+        onSubmit={() => {}}
+      />,
+    );
+    const wordHaus = screen.getByTestId("wordbank-0");
+
+    // 1) QuickPlace: 'Haus' in die erste Lücke setzen
+    fireEvent.click(wordHaus, { ctrlKey: true });
+    const blank = screen.getByTestId("blank-1");
+    expect(blank).toHaveTextContent("Haus");
+
+    // In der Bank sollte 'Haus' jetzt nicht mehr draggable sein
+    expect(screen.getByTestId("wordbank-0")).toHaveAttribute(
+      "draggable",
+      "false",
+    );
+
+    // 2) Ctrl-Klick auf die belegte Lücke => leeren
+    fireEvent.click(blank, { ctrlKey: true });
+
+    // Lücke wieder leer
+    expect(blank).toHaveTextContent("");
+
+    // 3) In der Bank ist 'Haus' wieder verfügbar (draggable=true)
+    const hausInBank = screen.getByTestId("wordbank-0");
+    expect(hausInBank).toHaveAttribute("draggable", "true");
+  });
+
+  describe("ClozeExercise – Feedback-Anzeige", () => {
+    it("zeigt ein Fehler-Feedback, wenn nicht alle Antworten korrekt sind", async () => {
+      const onSubmit = vi.fn();
+      render(
+        <ClozeExercise
+          clozeText={baseText}
+          showSolutionWords={false}
+          onSubmit={onSubmit}
+        />,
+      );
+
+      // Vorher kein Feedback
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+
+      // 1x falsch, 1x richtig
+      const inputs = screen.getAllByRole("textbox");
+      fireEvent.change(inputs[0], { target: { value: "falsch" } });
+      fireEvent.change(inputs[1], { target: { value: "GROSS" } });
+
+      // Prüfen
+      fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
+
+      // onSubmit nicht aufgerufen, Fehlermeldung sichtbar
+      expect(onSubmit).not.toHaveBeenCalled();
+      const status = await screen.findByRole("status");
+      expect(status).toBeInTheDocument();
+      expect(status).toHaveTextContent(/Noch nicht ganz:/i);
+      expect(status).toHaveTextContent(/1\s+von\s+2/i);
+      // Stilklasse für Fehler (aus der Komponente)
+      expect(status).toHaveClass("bg-red-50");
     });
 
-    it("füllt Lücken via QuickPlace (Ctrl/Cmd-Klick)", () => {
-        const onSubmit = vi.fn();
-        render(
-            <ClozeExercise
-                clozeText={baseText}
-                showSolutionWords={true}
-                wrongSolutionWords={["Baum"]}
-                onSubmit={onSubmit}
-            />,
-        );
+    it("zeigt ein Erfolgs-Feedback, wenn alle Antworten korrekt sind", async () => {
+      const onSubmit = vi.fn();
+      render(
+        <ClozeExercise
+          clozeText={baseText}
+          showSolutionWords={false}
+          onSubmit={onSubmit}
+        />,
+      );
 
-        // Wordbank vorhanden, enthält mindestens die beiden korrekten Erstlösungen + evtl. falsches Wort
-        const bank = screen.getByTestId("solution-words");
-        const wordHaus = screen.getByText("Haus");
-        const wordGross = screen.getByText("groß"); // aus correct[0] (falls es "groß" ist)
-        expect(bank).toBeInTheDocument();
-        expect(wordHaus).toBeInTheDocument();
-        expect(wordGross).toBeInTheDocument();
+      // Alles korrekt befüllen
+      const inputs = screen.getAllByRole("textbox");
+      fireEvent.change(inputs[0], { target: { value: "Haus" } });
+      fireEvent.change(inputs[1], { target: { value: "gross" } }); // erlaubt per correct[] Alternative
 
-        // QuickPlace: Ctrl-Klick auf "Haus" -> füllt erste freie Lücke
-        fireEvent.click(wordHaus, { ctrlKey: true });
+      // Prüfen
+      fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
 
-        const blank1 = screen.getByTestId("blank-1");
-        const blank3 = screen.getByTestId("blank-3");
-        expect(blank1).toHaveTextContent("Haus");
-
-        // Zweites Wort via Drag & Drop in zweite Lücke
-        const dtCapture = createDataTransfer();
-        // dragStart am Bank-Wort triggert setData("wordId", "<id>")
-        fireEvent.dragStart(wordGross, { dataTransfer: dtCapture });
-        const setDataCall = (dtCapture.setData as unknown as any).mock.calls.find(
-            (c: any[]) => c[0] === "wordId",
-        );
-        expect(setDataCall, "dragStart sollte wordId setzen").toBeTruthy();
-        const grossId = setDataCall[1] as string;
-
-        // Jetzt den Drop mit dieser ID auf die zweite Lücke ausführen
-        const dtDrop = createDataTransfer({ wordId: grossId });
-        fireEvent.dragOver(blank3, { dataTransfer: dtDrop });
-        fireEvent.drop(blank3, { dataTransfer: dtDrop });
-
-        // Beide Lücken sollten belegt sein
-        expect(blank1).toHaveTextContent("Haus");
-        expect(blank3).toHaveTextContent("groß");
-
-        // Button aktiv -> Submit -> True & onSubmit aufgerufen
-        const button = screen.getByRole("button", { name: "Prüfen" });
-        expect(button).toBeEnabled();
-        fireEvent.click(button);
-        expect(onSubmit).toHaveBeenCalledTimes(1);
+      // onSubmit aufgerufen, Erfolgsfeedback sichtbar
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      const status = await screen.findByRole("status");
+      expect(status).toBeInTheDocument();
+      expect(status).toHaveTextContent(/🎉 Alles richtig! Super gemacht!/i);
+      // Stilklasse für Erfolg (aus der Komponente)
+      expect(status).toHaveClass("bg-green-50");
     });
-
-    it("Rückgabe in die Wordbank (Drop auf Bank) räumt die Lücke wieder leer", () => {
-        render(
-            <ClozeExercise
-                clozeText={baseText}
-                showSolutionWords={true}
-                wrongSolutionWords={[]}
-                onSubmit={() => { }}
-            />,
-        );
-
-        const bank = screen.getByTestId("solution-words");
-        const wordHaus = screen.getByTestId("wordbank-0");
-
-        // Erst in erste Lücke packen (QuickPlace)
-        fireEvent.click(wordHaus, { ctrlKey: true });
-        const blank = screen.getByTestId("blank-1");
-        expect(blank).toHaveTextContent("Haus");
-
-        // Dann per Drop zurück in die Bank
-        const word = within(blank).getByText("Haus");
-        const dtCapture = createDataTransfer();
-        fireEvent.dragStart(word, { dataTransfer: dtCapture });
-        const setDataCall = (dtCapture.setData as unknown as any).mock.calls.find(
-            (c: any[]) => c[0] === "wordId",
-        );
-        const id = setDataCall?.[1] as string;
-
-        const dtDropBack = createDataTransfer({ wordId: id });
-        fireEvent.dragOver(bank, { dataTransfer: dtDropBack });
-        fireEvent.drop(bank, { dataTransfer: dtDropBack });
-
-        expect(blank).toHaveTextContent("");
-    });
-
-    it("Ctrl/Cmd-Klick auf belegte Lücke: Wort wird aus der Lücke entfernt und in der Wordbank wieder verfügbar", () => {
-        render(
-            <ClozeExercise
-                clozeText={baseText}
-                showSolutionWords={true}
-                wrongSolutionWords={[]}
-                onSubmit={() => { }}
-            />,
-        );
-        const wordHaus = screen.getByTestId("wordbank-0");
-
-        // 1) QuickPlace: 'Haus' in die erste Lücke setzen
-        fireEvent.click(wordHaus, { ctrlKey: true });
-        const blank = screen.getByTestId("blank-1");
-        expect(blank).toHaveTextContent("Haus");
-
-        // In der Bank sollte 'Haus' jetzt nicht mehr draggable sein
-        expect(screen.getByTestId("wordbank-0")).toHaveAttribute(
-            "draggable",
-            "false",
-        );
-
-        // 2) Ctrl-Klick auf die belegte Lücke => leeren
-        fireEvent.click(blank, { ctrlKey: true });
-
-        // Lücke wieder leer
-        expect(blank).toHaveTextContent("");
-
-        // 3) In der Bank ist 'Haus' wieder verfügbar (draggable=true)
-        const hausInBank = screen.getByTestId("wordbank-0");
-        expect(hausInBank).toHaveAttribute("draggable", "true");
-    });
-
-    describe("ClozeExercise – Feedback-Anzeige", () => {
-        it("zeigt ein Fehler-Feedback, wenn nicht alle Antworten korrekt sind", async () => {
-            const onSubmit = vi.fn();
-            render(
-                <ClozeExercise
-                    clozeText={baseText}
-                    showSolutionWords={false}
-                    onSubmit={onSubmit}
-                />,
-            );
-
-            // Vorher kein Feedback
-            expect(screen.queryByRole("status")).not.toBeInTheDocument();
-
-            // 1x falsch, 1x richtig
-            const inputs = screen.getAllByRole("textbox");
-            fireEvent.change(inputs[0], { target: { value: "falsch" } });
-            fireEvent.change(inputs[1], { target: { value: "GROSS" } });
-
-            // Prüfen
-            fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
-
-            // onSubmit nicht aufgerufen, Fehlermeldung sichtbar
-            expect(onSubmit).not.toHaveBeenCalled();
-            const status = await screen.findByRole("status");
-            expect(status).toBeInTheDocument();
-            expect(status).toHaveTextContent(/Noch nicht ganz:/i);
-            expect(status).toHaveTextContent(/1\s+von\s+2/i);
-            // Stilklasse für Fehler (aus der Komponente)
-            expect(status).toHaveClass("bg-red-50");
-        });
-
-        it("zeigt ein Erfolgs-Feedback, wenn alle Antworten korrekt sind", async () => {
-            const onSubmit = vi.fn();
-            render(
-                <ClozeExercise
-                    clozeText={baseText}
-                    showSolutionWords={false}
-                    onSubmit={onSubmit}
-                />,
-            );
-
-            // Alles korrekt befüllen
-            const inputs = screen.getAllByRole("textbox");
-            fireEvent.change(inputs[0], { target: { value: "Haus" } });
-            fireEvent.change(inputs[1], { target: { value: "gross" } }); // erlaubt per correct[] Alternative
-
-            // Prüfen
-            fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
-
-            // onSubmit aufgerufen, Erfolgsfeedback sichtbar
-            expect(onSubmit).toHaveBeenCalledTimes(1);
-            const status = await screen.findByRole("status");
-            expect(status).toBeInTheDocument();
-            expect(status).toHaveTextContent(/🎉 Alles richtig! Super gemacht!/i);
-            // Stilklasse für Erfolg (aus der Komponente)
-            expect(status).toHaveClass("bg-green-50");
-        });
-    });
+  });
 });

--- a/frontend/tests/components/cloze-exercise/ClozeExercise.test.tsx
+++ b/frontend/tests/components/cloze-exercise/ClozeExercise.test.tsx
@@ -253,5 +253,4 @@ describe("ClozeExercise – Drag&Drop-Modus (showSolutionWords=true)", () => {
             expect(status).toHaveClass("bg-green-50");
         });
     });
-
 });

--- a/frontend/tests/components/cloze-exercise/ClozeExercise.test.tsx
+++ b/frontend/tests/components/cloze-exercise/ClozeExercise.test.tsx
@@ -193,4 +193,65 @@ describe("ClozeExercise – Drag&Drop-Modus (showSolutionWords=true)", () => {
         const hausInBank = screen.getByTestId("wordbank-0");
         expect(hausInBank).toHaveAttribute("draggable", "true");
     });
+
+    describe("ClozeExercise – Feedback-Anzeige", () => {
+        it("zeigt ein Fehler-Feedback, wenn nicht alle Antworten korrekt sind", async () => {
+            const onSubmit = vi.fn();
+            render(
+                <ClozeExercise
+                    clozeText={baseText}
+                    showSolutionWords={false}
+                    onSubmit={onSubmit}
+                />
+            );
+
+            // Vorher kein Feedback
+            expect(screen.queryByRole("status")).not.toBeInTheDocument();
+
+            // 1x falsch, 1x richtig
+            const inputs = screen.getAllByRole("textbox");
+            fireEvent.change(inputs[0], { target: { value: "falsch" } });
+            fireEvent.change(inputs[1], { target: { value: "GROSS" } });
+
+            // Prüfen
+            fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
+
+            // onSubmit nicht aufgerufen, Fehlermeldung sichtbar
+            expect(onSubmit).not.toHaveBeenCalled();
+            const status = await screen.findByRole("status");
+            expect(status).toBeInTheDocument();
+            expect(status).toHaveTextContent(/Noch nicht ganz:/i);
+            expect(status).toHaveTextContent(/1\s+von\s+2/i);
+            // Stilklasse für Fehler (aus der Komponente)
+            expect(status).toHaveClass("bg-red-50");
+        });
+
+        it("zeigt ein Erfolgs-Feedback, wenn alle Antworten korrekt sind", async () => {
+            const onSubmit = vi.fn();
+            render(
+                <ClozeExercise
+                    clozeText={baseText}
+                    showSolutionWords={false}
+                    onSubmit={onSubmit}
+                />
+            );
+
+            // Alles korrekt befüllen
+            const inputs = screen.getAllByRole("textbox");
+            fireEvent.change(inputs[0], { target: { value: "Haus" } });
+            fireEvent.change(inputs[1], { target: { value: "gross" } }); // erlaubt per correct[] Alternative
+
+            // Prüfen
+            fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
+
+            // onSubmit aufgerufen, Erfolgsfeedback sichtbar
+            expect(onSubmit).toHaveBeenCalledTimes(1);
+            const status = await screen.findByRole("status");
+            expect(status).toBeInTheDocument();
+            expect(status).toHaveTextContent(/Alles richtig! Super gemacht!/i);
+            // Stilklasse für Erfolg (aus der Komponente)
+            expect(status).toHaveClass("bg-green-50");
+        });
+    });
+
 });

--- a/frontend/tests/components/cloze-exercise/ClozeExercise.test.tsx
+++ b/frontend/tests/components/cloze-exercise/ClozeExercise.test.tsx
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import ClozeExercise, { ClozeTextPart, ClozeResult } from "@/components/ui_elements/cloze_exercise/ClozeExercise";
+
+// Layout-Komponente mocken (wir wollen nur die Kinder rendern)
+vi.mock("@/components/layouts", () => ({
+    SubBackground: ({ children }: { children: React.ReactNode }) => (
+        <div data-testid="subbackground">{children}</div>
+    ),
+}));
+
+// Helfer für DataTransfer im DnD
+function createDataTransfer(initial: Record<string, string> = {}) {
+    const store = { ...initial };
+    return {
+        setData: vi.fn((k: string, v: string) => { store[k] = v; }),
+        getData: vi.fn((k: string) => store[k]),
+        dropEffect: "move",
+        effectAllowed: "all",
+        files: [],
+        items: [],
+        types: Object.keys(store),
+    } as unknown as DataTransfer;
+}
+
+const baseText: ClozeTextPart[] = [
+    { type: "text", content: "Das" },
+    { type: "blank", correct: ["Haus"] },
+    { type: "text", content: "ist" },
+    { type: "blank", correct: ["groß", "gross"] },
+    { type: "text", content: "." },
+];
+
+describe("ClozeExercise – Input-Modus (showSolutionWords=false)", () => {
+    it("aktiviert den Submit-Button erst wenn alle Lücken gefüllt sind und ruft onSubmit nur bei korrekten Antworten", () => {
+        const onSubmit = vi.fn();
+        render(
+            <ClozeExercise
+                title="Fülle die Lücken aus:"
+                clozeText={baseText}
+                showSolutionWords={false}
+                onSubmit={onSubmit}
+            />
+        );
+
+        // Button ist anfangs disabled
+        const button = screen.getByRole("button", { name: "Prüfen" });
+        expect(button).toBeDisabled();
+
+        // Beide Inputs befüllen (1x absichtlich falsch)
+        const inputs = screen.getAllByRole("textbox");
+        expect(inputs).toHaveLength(2);
+
+        // Erste Lücke falsch
+        fireEvent.change(inputs[0], { target: { value: "falsch" } });
+        // Zweite Lücke korrekt (case-insensitiv)
+        fireEvent.change(inputs[1], { target: { value: "GROSS" } });
+
+        // Jetzt sind alle gefüllt -> Button enabled
+        expect(button).toBeEnabled();
+
+        // Submit (falsch + korrekt) -> Label "False", onSubmit NICHT aufgerufen
+        fireEvent.click(button);
+        expect(onSubmit).not.toHaveBeenCalled();
+
+        // Korrigieren und erneut submitten
+        fireEvent.change(inputs[0], { target: { value: "Haus" } });
+        fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
+
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("ClozeExercise – Drag&Drop-Modus (showSolutionWords=true)", () => {
+    beforeEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("füllt Lücken via QuickPlace (Ctrl/Cmd-Klick)", () => {
+        const onSubmit = vi.fn();
+        render(
+            <ClozeExercise
+                clozeText={baseText}
+                showSolutionWords={true}
+                wrongSolutionWords={["Baum"]}
+                onSubmit={onSubmit}
+            />
+        );
+
+        // Wordbank vorhanden, enthält mindestens die beiden korrekten Erstlösungen + evtl. falsches Wort
+        const bank = screen.getByTestId("solution-words");
+        const wordHaus = screen.getByText("Haus");
+        const wordGross = screen.getByText("groß"); // aus correct[0] (falls es "groß" ist)
+        expect(bank).toBeInTheDocument();
+        expect(wordHaus).toBeInTheDocument();
+        expect(wordGross).toBeInTheDocument();
+
+        // QuickPlace: Ctrl-Klick auf "Haus" -> füllt erste freie Lücke
+        fireEvent.click(wordHaus, { ctrlKey: true });
+
+        const blank1 = screen.getByTestId("blank-1");
+        const blank3 = screen.getByTestId("blank-3");
+        expect(blank1).toHaveTextContent("Haus");
+
+        // Zweites Wort via Drag & Drop in zweite Lücke
+        const dtCapture = createDataTransfer();
+        // dragStart am Bank-Wort triggert setData("wordId", "<id>")
+        fireEvent.dragStart(wordGross, { dataTransfer: dtCapture });
+        const setDataCall = (dtCapture.setData as unknown as any).mock.calls.find(
+            (c: any[]) => c[0] === "wordId"
+        );
+        expect(setDataCall, "dragStart sollte wordId setzen").toBeTruthy();
+        const grossId = setDataCall[1] as string;
+
+        // Jetzt den Drop mit dieser ID auf die zweite Lücke ausführen
+        const dtDrop = createDataTransfer({ wordId: grossId });
+        fireEvent.dragOver(blank3, { dataTransfer: dtDrop });
+        fireEvent.drop(blank3, { dataTransfer: dtDrop });
+
+        // Beide Lücken sollten belegt sein
+        expect(blank1).toHaveTextContent("Haus");
+        expect(blank3).toHaveTextContent("groß");
+
+        // Button aktiv -> Submit -> True & onSubmit aufgerufen
+        const button = screen.getByRole("button", { name: "Prüfen" });
+        expect(button).toBeEnabled();
+        fireEvent.click(button);
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    it("Rückgabe in die Wordbank (Drop auf Bank) räumt die Lücke wieder leer", () => {
+        render(
+            <ClozeExercise
+                clozeText={baseText}
+                showSolutionWords={true}
+                wrongSolutionWords={[]}
+                onSubmit={() => { }}
+            />
+        );
+
+        const bank = screen.getByTestId("solution-words");
+        const wordHaus = screen.getByTestId("wordbank-0");
+
+        // Erst in erste Lücke packen (QuickPlace)
+        fireEvent.click(wordHaus, { ctrlKey: true });
+        const blank = screen.getByTestId("blank-1");
+        expect(blank).toHaveTextContent("Haus");
+
+        // Dann per Drop zurück in die Bank
+        const word = within(blank).getByText("Haus");
+        const dtCapture = createDataTransfer();
+        fireEvent.dragStart(word, { dataTransfer: dtCapture });
+        const setDataCall = (dtCapture.setData as unknown as any).mock.calls.find(
+            (c: any[]) => c[0] === "wordId"
+        );
+        const id = setDataCall?.[1] as string;
+
+        const dtDropBack = createDataTransfer({ wordId: id });
+        fireEvent.dragOver(bank, { dataTransfer: dtDropBack });
+        fireEvent.drop(bank, { dataTransfer: dtDropBack });
+
+        expect(blank).toHaveTextContent("");
+    });
+
+    it("Ctrl/Cmd-Klick auf belegte Lücke: Wort wird aus der Lücke entfernt und in der Wordbank wieder verfügbar", () => {
+        render(
+            <ClozeExercise
+                clozeText={baseText}
+                showSolutionWords={true}
+                wrongSolutionWords={[]}
+                onSubmit={() => { }}
+            />
+        );
+        const wordHaus = screen.getByTestId("wordbank-0");
+
+        // 1) QuickPlace: 'Haus' in die erste Lücke setzen
+        fireEvent.click(wordHaus, { ctrlKey: true });
+        const blank = screen.getByTestId("blank-1");
+        expect(blank).toHaveTextContent("Haus");
+
+        // In der Bank sollte 'Haus' jetzt nicht mehr draggable sein
+        expect(screen.getByTestId("wordbank-0")).toHaveAttribute("draggable", "false");
+
+        // 2) Ctrl-Klick auf die belegte Lücke => leeren
+        fireEvent.click(blank, { ctrlKey: true });
+
+        // Lücke wieder leer
+        expect(blank).toHaveTextContent("");
+
+        // 3) In der Bank ist 'Haus' wieder verfügbar (draggable=true)
+        const hausInBank = screen.getByTestId("wordbank-0");
+        expect(hausInBank).toHaveAttribute("draggable", "true");
+    });
+});

--- a/frontend/tests/components/cloze-exercise/ClozeExercise.test.tsx
+++ b/frontend/tests/components/cloze-exercise/ClozeExercise.test.tsx
@@ -3,262 +3,262 @@ import React from "react";
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import ClozeExercise, {
-  ClozeTextPart,
-  ClozeResult,
+    ClozeTextPart,
+    ClozeResult,
 } from "@/components/ui_elements/cloze_exercise/ClozeExercise";
 
 // Layout-Komponente mocken (wir wollen nur die Kinder rendern)
 vi.mock("@/components/layouts", () => ({
-  SubBackground: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="subbackground">{children}</div>
-  ),
+    SubBackground: ({ children }: { children: React.ReactNode }) => (
+        <div data-testid="subbackground">{children}</div>
+    ),
 }));
 
 // Helfer für DataTransfer im DnD
 function createDataTransfer(initial: Record<string, string> = {}) {
-  const store = { ...initial };
-  return {
-    setData: vi.fn((k: string, v: string) => {
-      store[k] = v;
-    }),
-    getData: vi.fn((k: string) => store[k]),
-    dropEffect: "move",
-    effectAllowed: "all",
-    files: [],
-    items: [],
-    types: Object.keys(store),
-  } as unknown as DataTransfer;
+    const store = { ...initial };
+    return {
+        setData: vi.fn((k: string, v: string) => {
+            store[k] = v;
+        }),
+        getData: vi.fn((k: string) => store[k]),
+        dropEffect: "move",
+        effectAllowed: "all",
+        files: [],
+        items: [],
+        types: Object.keys(store),
+    } as unknown as DataTransfer;
 }
 
 const baseText: ClozeTextPart[] = [
-  { type: "text", content: "Das" },
-  { type: "blank", correct: ["Haus"] },
-  { type: "text", content: "ist" },
-  { type: "blank", correct: ["groß", "gross"] },
-  { type: "text", content: "." },
+    { type: "text", content: "Das" },
+    { type: "blank", correct: ["Haus"] },
+    { type: "text", content: "ist" },
+    { type: "blank", correct: ["groß", "gross"] },
+    { type: "text", content: "." },
 ];
 
 describe("ClozeExercise – Input-Modus (showSolutionWords=false)", () => {
-  it("aktiviert den Submit-Button erst wenn alle Lücken gefüllt sind und ruft onSubmit nur bei korrekten Antworten", () => {
-    const onSubmit = vi.fn();
-    render(
-      <ClozeExercise
-        title="Fülle die Lücken aus:"
-        clozeText={baseText}
-        showSolutionWords={false}
-        onSubmit={onSubmit}
-      />,
-    );
+    it("aktiviert den Submit-Button erst wenn alle Lücken gefüllt sind und ruft onSubmit nur bei korrekten Antworten", () => {
+        const onSubmit = vi.fn();
+        render(
+            <ClozeExercise
+                title="Fülle die Lücken aus:"
+                clozeText={baseText}
+                showSolutionWords={false}
+                onSubmit={onSubmit}
+            />,
+        );
 
-    // Button ist anfangs disabled
-    const button = screen.getByRole("button", { name: "Prüfen" });
-    expect(button).toBeDisabled();
+        // Button ist anfangs disabled
+        const button = screen.getByRole("button", { name: "Prüfen" });
+        expect(button).toBeDisabled();
 
-    // Beide Inputs befüllen (1x absichtlich falsch)
-    const inputs = screen.getAllByRole("textbox");
-    expect(inputs).toHaveLength(2);
+        // Beide Inputs befüllen (1x absichtlich falsch)
+        const inputs = screen.getAllByRole("textbox");
+        expect(inputs).toHaveLength(2);
 
-    // Erste Lücke falsch
-    fireEvent.change(inputs[0], { target: { value: "falsch" } });
-    // Zweite Lücke korrekt (case-insensitiv)
-    fireEvent.change(inputs[1], { target: { value: "GROSS" } });
+        // Erste Lücke falsch
+        fireEvent.change(inputs[0], { target: { value: "falsch" } });
+        // Zweite Lücke korrekt (case-insensitiv)
+        fireEvent.change(inputs[1], { target: { value: "GROSS" } });
 
-    // Jetzt sind alle gefüllt -> Button enabled
-    expect(button).toBeEnabled();
+        // Jetzt sind alle gefüllt -> Button enabled
+        expect(button).toBeEnabled();
 
-    // Submit (falsch + korrekt) -> Label "False", onSubmit NICHT aufgerufen
-    fireEvent.click(button);
-    expect(onSubmit).not.toHaveBeenCalled();
+        // Submit (falsch + korrekt) -> Label "False", onSubmit NICHT aufgerufen
+        fireEvent.click(button);
+        expect(onSubmit).not.toHaveBeenCalled();
 
-    // Korrigieren und erneut submitten
-    fireEvent.change(inputs[0], { target: { value: "Haus" } });
-    fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
+        // Korrigieren und erneut submitten
+        fireEvent.change(inputs[0], { target: { value: "Haus" } });
+        fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
 
-    expect(onSubmit).toHaveBeenCalledTimes(1);
-  });
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
 });
 
 describe("ClozeExercise – Drag&Drop-Modus (showSolutionWords=true)", () => {
-  beforeEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("füllt Lücken via QuickPlace (Ctrl/Cmd-Klick)", () => {
-    const onSubmit = vi.fn();
-    render(
-      <ClozeExercise
-        clozeText={baseText}
-        showSolutionWords={true}
-        wrongSolutionWords={["Baum"]}
-        onSubmit={onSubmit}
-      />,
-    );
-
-    // Wordbank vorhanden, enthält mindestens die beiden korrekten Erstlösungen + evtl. falsches Wort
-    const bank = screen.getByTestId("solution-words");
-    const wordHaus = screen.getByText("Haus");
-    const wordGross = screen.getByText("groß"); // aus correct[0] (falls es "groß" ist)
-    expect(bank).toBeInTheDocument();
-    expect(wordHaus).toBeInTheDocument();
-    expect(wordGross).toBeInTheDocument();
-
-    // QuickPlace: Ctrl-Klick auf "Haus" -> füllt erste freie Lücke
-    fireEvent.click(wordHaus, { ctrlKey: true });
-
-    const blank1 = screen.getByTestId("blank-1");
-    const blank3 = screen.getByTestId("blank-3");
-    expect(blank1).toHaveTextContent("Haus");
-
-    // Zweites Wort via Drag & Drop in zweite Lücke
-    const dtCapture = createDataTransfer();
-    // dragStart am Bank-Wort triggert setData("wordId", "<id>")
-    fireEvent.dragStart(wordGross, { dataTransfer: dtCapture });
-    const setDataCall = (dtCapture.setData as unknown as any).mock.calls.find(
-      (c: any[]) => c[0] === "wordId",
-    );
-    expect(setDataCall, "dragStart sollte wordId setzen").toBeTruthy();
-    const grossId = setDataCall[1] as string;
-
-    // Jetzt den Drop mit dieser ID auf die zweite Lücke ausführen
-    const dtDrop = createDataTransfer({ wordId: grossId });
-    fireEvent.dragOver(blank3, { dataTransfer: dtDrop });
-    fireEvent.drop(blank3, { dataTransfer: dtDrop });
-
-    // Beide Lücken sollten belegt sein
-    expect(blank1).toHaveTextContent("Haus");
-    expect(blank3).toHaveTextContent("groß");
-
-    // Button aktiv -> Submit -> True & onSubmit aufgerufen
-    const button = screen.getByRole("button", { name: "Prüfen" });
-    expect(button).toBeEnabled();
-    fireEvent.click(button);
-    expect(onSubmit).toHaveBeenCalledTimes(1);
-  });
-
-  it("Rückgabe in die Wordbank (Drop auf Bank) räumt die Lücke wieder leer", () => {
-    render(
-      <ClozeExercise
-        clozeText={baseText}
-        showSolutionWords={true}
-        wrongSolutionWords={[]}
-        onSubmit={() => {}}
-      />,
-    );
-
-    const bank = screen.getByTestId("solution-words");
-    const wordHaus = screen.getByTestId("wordbank-0");
-
-    // Erst in erste Lücke packen (QuickPlace)
-    fireEvent.click(wordHaus, { ctrlKey: true });
-    const blank = screen.getByTestId("blank-1");
-    expect(blank).toHaveTextContent("Haus");
-
-    // Dann per Drop zurück in die Bank
-    const word = within(blank).getByText("Haus");
-    const dtCapture = createDataTransfer();
-    fireEvent.dragStart(word, { dataTransfer: dtCapture });
-    const setDataCall = (dtCapture.setData as unknown as any).mock.calls.find(
-      (c: any[]) => c[0] === "wordId",
-    );
-    const id = setDataCall?.[1] as string;
-
-    const dtDropBack = createDataTransfer({ wordId: id });
-    fireEvent.dragOver(bank, { dataTransfer: dtDropBack });
-    fireEvent.drop(bank, { dataTransfer: dtDropBack });
-
-    expect(blank).toHaveTextContent("");
-  });
-
-  it("Ctrl/Cmd-Klick auf belegte Lücke: Wort wird aus der Lücke entfernt und in der Wordbank wieder verfügbar", () => {
-    render(
-      <ClozeExercise
-        clozeText={baseText}
-        showSolutionWords={true}
-        wrongSolutionWords={[]}
-        onSubmit={() => {}}
-      />,
-    );
-    const wordHaus = screen.getByTestId("wordbank-0");
-
-    // 1) QuickPlace: 'Haus' in die erste Lücke setzen
-    fireEvent.click(wordHaus, { ctrlKey: true });
-    const blank = screen.getByTestId("blank-1");
-    expect(blank).toHaveTextContent("Haus");
-
-    // In der Bank sollte 'Haus' jetzt nicht mehr draggable sein
-    expect(screen.getByTestId("wordbank-0")).toHaveAttribute(
-      "draggable",
-      "false",
-    );
-
-    // 2) Ctrl-Klick auf die belegte Lücke => leeren
-    fireEvent.click(blank, { ctrlKey: true });
-
-    // Lücke wieder leer
-    expect(blank).toHaveTextContent("");
-
-    // 3) In der Bank ist 'Haus' wieder verfügbar (draggable=true)
-    const hausInBank = screen.getByTestId("wordbank-0");
-    expect(hausInBank).toHaveAttribute("draggable", "true");
-  });
-
-  describe("ClozeExercise – Feedback-Anzeige", () => {
-    it("zeigt ein Fehler-Feedback, wenn nicht alle Antworten korrekt sind", async () => {
-      const onSubmit = vi.fn();
-      render(
-        <ClozeExercise
-          clozeText={baseText}
-          showSolutionWords={false}
-          onSubmit={onSubmit}
-        />,
-      );
-
-      // Vorher kein Feedback
-      expect(screen.queryByRole("status")).not.toBeInTheDocument();
-
-      // 1x falsch, 1x richtig
-      const inputs = screen.getAllByRole("textbox");
-      fireEvent.change(inputs[0], { target: { value: "falsch" } });
-      fireEvent.change(inputs[1], { target: { value: "GROSS" } });
-
-      // Prüfen
-      fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
-
-      // onSubmit nicht aufgerufen, Fehlermeldung sichtbar
-      expect(onSubmit).not.toHaveBeenCalled();
-      const status = await screen.findByRole("status");
-      expect(status).toBeInTheDocument();
-      expect(status).toHaveTextContent(/Noch nicht ganz:/i);
-      expect(status).toHaveTextContent(/1\s+von\s+2/i);
-      // Stilklasse für Fehler (aus der Komponente)
-      expect(status).toHaveClass("bg-red-50");
+    beforeEach(() => {
+        vi.useRealTimers();
     });
 
-    it("zeigt ein Erfolgs-Feedback, wenn alle Antworten korrekt sind", async () => {
-      const onSubmit = vi.fn();
-      render(
-        <ClozeExercise
-          clozeText={baseText}
-          showSolutionWords={false}
-          onSubmit={onSubmit}
-        />,
-      );
+    it("füllt Lücken via QuickPlace (Ctrl/Cmd-Klick)", () => {
+        const onSubmit = vi.fn();
+        render(
+            <ClozeExercise
+                clozeText={baseText}
+                showSolutionWords={true}
+                wrongSolutionWords={["Baum"]}
+                onSubmit={onSubmit}
+            />,
+        );
 
-      // Alles korrekt befüllen
-      const inputs = screen.getAllByRole("textbox");
-      fireEvent.change(inputs[0], { target: { value: "Haus" } });
-      fireEvent.change(inputs[1], { target: { value: "gross" } }); // erlaubt per correct[] Alternative
+        // Wordbank vorhanden, enthält mindestens die beiden korrekten Erstlösungen + evtl. falsches Wort
+        const bank = screen.getByTestId("solution-words");
+        const wordHaus = screen.getByText("Haus");
+        const wordGross = screen.getByText("groß"); // aus correct[0] (falls es "groß" ist)
+        expect(bank).toBeInTheDocument();
+        expect(wordHaus).toBeInTheDocument();
+        expect(wordGross).toBeInTheDocument();
 
-      // Prüfen
-      fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
+        // QuickPlace: Ctrl-Klick auf "Haus" -> füllt erste freie Lücke
+        fireEvent.click(wordHaus, { ctrlKey: true });
 
-      // onSubmit aufgerufen, Erfolgsfeedback sichtbar
-      expect(onSubmit).toHaveBeenCalledTimes(1);
-      const status = await screen.findByRole("status");
-      expect(status).toBeInTheDocument();
-      expect(status).toHaveTextContent(/Alles richtig! Super gemacht!/i);
-      // Stilklasse für Erfolg (aus der Komponente)
-      expect(status).toHaveClass("bg-green-50");
+        const blank1 = screen.getByTestId("blank-1");
+        const blank3 = screen.getByTestId("blank-3");
+        expect(blank1).toHaveTextContent("Haus");
+
+        // Zweites Wort via Drag & Drop in zweite Lücke
+        const dtCapture = createDataTransfer();
+        // dragStart am Bank-Wort triggert setData("wordId", "<id>")
+        fireEvent.dragStart(wordGross, { dataTransfer: dtCapture });
+        const setDataCall = (dtCapture.setData as unknown as any).mock.calls.find(
+            (c: any[]) => c[0] === "wordId",
+        );
+        expect(setDataCall, "dragStart sollte wordId setzen").toBeTruthy();
+        const grossId = setDataCall[1] as string;
+
+        // Jetzt den Drop mit dieser ID auf die zweite Lücke ausführen
+        const dtDrop = createDataTransfer({ wordId: grossId });
+        fireEvent.dragOver(blank3, { dataTransfer: dtDrop });
+        fireEvent.drop(blank3, { dataTransfer: dtDrop });
+
+        // Beide Lücken sollten belegt sein
+        expect(blank1).toHaveTextContent("Haus");
+        expect(blank3).toHaveTextContent("groß");
+
+        // Button aktiv -> Submit -> True & onSubmit aufgerufen
+        const button = screen.getByRole("button", { name: "Prüfen" });
+        expect(button).toBeEnabled();
+        fireEvent.click(button);
+        expect(onSubmit).toHaveBeenCalledTimes(1);
     });
-  });
+
+    it("Rückgabe in die Wordbank (Drop auf Bank) räumt die Lücke wieder leer", () => {
+        render(
+            <ClozeExercise
+                clozeText={baseText}
+                showSolutionWords={true}
+                wrongSolutionWords={[]}
+                onSubmit={() => { }}
+            />,
+        );
+
+        const bank = screen.getByTestId("solution-words");
+        const wordHaus = screen.getByTestId("wordbank-0");
+
+        // Erst in erste Lücke packen (QuickPlace)
+        fireEvent.click(wordHaus, { ctrlKey: true });
+        const blank = screen.getByTestId("blank-1");
+        expect(blank).toHaveTextContent("Haus");
+
+        // Dann per Drop zurück in die Bank
+        const word = within(blank).getByText("Haus");
+        const dtCapture = createDataTransfer();
+        fireEvent.dragStart(word, { dataTransfer: dtCapture });
+        const setDataCall = (dtCapture.setData as unknown as any).mock.calls.find(
+            (c: any[]) => c[0] === "wordId",
+        );
+        const id = setDataCall?.[1] as string;
+
+        const dtDropBack = createDataTransfer({ wordId: id });
+        fireEvent.dragOver(bank, { dataTransfer: dtDropBack });
+        fireEvent.drop(bank, { dataTransfer: dtDropBack });
+
+        expect(blank).toHaveTextContent("");
+    });
+
+    it("Ctrl/Cmd-Klick auf belegte Lücke: Wort wird aus der Lücke entfernt und in der Wordbank wieder verfügbar", () => {
+        render(
+            <ClozeExercise
+                clozeText={baseText}
+                showSolutionWords={true}
+                wrongSolutionWords={[]}
+                onSubmit={() => { }}
+            />,
+        );
+        const wordHaus = screen.getByTestId("wordbank-0");
+
+        // 1) QuickPlace: 'Haus' in die erste Lücke setzen
+        fireEvent.click(wordHaus, { ctrlKey: true });
+        const blank = screen.getByTestId("blank-1");
+        expect(blank).toHaveTextContent("Haus");
+
+        // In der Bank sollte 'Haus' jetzt nicht mehr draggable sein
+        expect(screen.getByTestId("wordbank-0")).toHaveAttribute(
+            "draggable",
+            "false",
+        );
+
+        // 2) Ctrl-Klick auf die belegte Lücke => leeren
+        fireEvent.click(blank, { ctrlKey: true });
+
+        // Lücke wieder leer
+        expect(blank).toHaveTextContent("");
+
+        // 3) In der Bank ist 'Haus' wieder verfügbar (draggable=true)
+        const hausInBank = screen.getByTestId("wordbank-0");
+        expect(hausInBank).toHaveAttribute("draggable", "true");
+    });
+
+    describe("ClozeExercise – Feedback-Anzeige", () => {
+        it("zeigt ein Fehler-Feedback, wenn nicht alle Antworten korrekt sind", async () => {
+            const onSubmit = vi.fn();
+            render(
+                <ClozeExercise
+                    clozeText={baseText}
+                    showSolutionWords={false}
+                    onSubmit={onSubmit}
+                />,
+            );
+
+            // Vorher kein Feedback
+            expect(screen.queryByRole("status")).not.toBeInTheDocument();
+
+            // 1x falsch, 1x richtig
+            const inputs = screen.getAllByRole("textbox");
+            fireEvent.change(inputs[0], { target: { value: "falsch" } });
+            fireEvent.change(inputs[1], { target: { value: "GROSS" } });
+
+            // Prüfen
+            fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
+
+            // onSubmit nicht aufgerufen, Fehlermeldung sichtbar
+            expect(onSubmit).not.toHaveBeenCalled();
+            const status = await screen.findByRole("status");
+            expect(status).toBeInTheDocument();
+            expect(status).toHaveTextContent(/Noch nicht ganz:/i);
+            expect(status).toHaveTextContent(/1\s+von\s+2/i);
+            // Stilklasse für Fehler (aus der Komponente)
+            expect(status).toHaveClass("bg-red-50");
+        });
+
+        it("zeigt ein Erfolgs-Feedback, wenn alle Antworten korrekt sind", async () => {
+            const onSubmit = vi.fn();
+            render(
+                <ClozeExercise
+                    clozeText={baseText}
+                    showSolutionWords={false}
+                    onSubmit={onSubmit}
+                />,
+            );
+
+            // Alles korrekt befüllen
+            const inputs = screen.getAllByRole("textbox");
+            fireEvent.change(inputs[0], { target: { value: "Haus" } });
+            fireEvent.change(inputs[1], { target: { value: "gross" } }); // erlaubt per correct[] Alternative
+
+            // Prüfen
+            fireEvent.click(screen.getByRole("button", { name: "Prüfen" }));
+
+            // onSubmit aufgerufen, Erfolgsfeedback sichtbar
+            expect(onSubmit).toHaveBeenCalledTimes(1);
+            const status = await screen.findByRole("status");
+            expect(status).toBeInTheDocument();
+            expect(status).toHaveTextContent(/🎉 Alles richtig! Super gemacht!/i);
+            // Stilklasse für Erfolg (aus der Komponente)
+            expect(status).toHaveClass("bg-green-50");
+        });
+    });
 });

--- a/frontend/tests/components/cloze-exercise/ClozeHeader.test.tsx
+++ b/frontend/tests/components/cloze-exercise/ClozeHeader.test.tsx
@@ -4,10 +4,10 @@ import "@testing-library/jest-dom/vitest";
 import ClozeHeader from "@/components/ui_elements/cloze_exercise/ClozeHeader";
 
 describe("ClozeHeader", () => {
-    it("renders Title", () => {
-        const title = "Fülle die Lücken aus:";
-        render(<ClozeHeader title={title} />);
-        const heading = screen.getByRole("heading", { name: title, level: 1 });
-        expect(heading).toBeInTheDocument();
-    });
+  it("renders Title", () => {
+    const title = "Fülle die Lücken aus:";
+    render(<ClozeHeader title={title} />);
+    const heading = screen.getByRole("heading", { name: title, level: 1 });
+    expect(heading).toBeInTheDocument();
+  });
 });

--- a/frontend/tests/components/cloze-exercise/ClozeHeader.test.tsx
+++ b/frontend/tests/components/cloze-exercise/ClozeHeader.test.tsx
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import ClozeHeader from "@/components/ui_elements/cloze_exercise/ClozeHeader";
+
+describe("ClozeHeader", () => {
+    it("renders Title", () => {
+        const title = "Fülle die Lücken aus:";
+        render(<ClozeHeader title={title} />);
+        const heading = screen.getByRole("heading", { name: title, level: 1 });
+        expect(heading).toBeInTheDocument();
+    });
+});

--- a/frontend/tests/components/cloze-exercise/ClozeSubmitButton.test.tsx
+++ b/frontend/tests/components/cloze-exercise/ClozeSubmitButton.test.tsx
@@ -4,27 +4,29 @@ import "@testing-library/jest-dom/vitest";
 import ClozeSubmitButton from "@/components/ui_elements/cloze_exercise/ClozeSubmitButton";
 
 describe("ClozeSubmitButton", () => {
-    it("rendert das übergebene Label", () => {
-        render(<ClozeSubmitButton disabled={false} label="Prüfen" onClick={() => { }} />);
-        expect(screen.getByRole("button", { name: "Prüfen" })).toBeInTheDocument();
-    });
+  it("rendert das übergebene Label", () => {
+    render(
+      <ClozeSubmitButton disabled={false} label="Prüfen" onClick={() => {}} />,
+    );
+    expect(screen.getByRole("button", { name: "Prüfen" })).toBeInTheDocument();
+  });
 
-    it("ruft onClick auf, wenn enabled", () => {
-        const onClick = vi.fn();
-        render(<ClozeSubmitButton disabled={false} label="OK" onClick={onClick} />);
+  it("ruft onClick auf, wenn enabled", () => {
+    const onClick = vi.fn();
+    render(<ClozeSubmitButton disabled={false} label="OK" onClick={onClick} />);
 
-        fireEvent.click(screen.getByRole("button", { name: "OK" }));
-        expect(onClick).toHaveBeenCalledTimes(1);
-    });
+    fireEvent.click(screen.getByRole("button", { name: "OK" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
 
-    it("ruft onClick NICHT auf, wenn disabled", () => {
-        const onClick = vi.fn();
-        render(<ClozeSubmitButton disabled={true} label="OK" onClick={onClick} />);
+  it("ruft onClick NICHT auf, wenn disabled", () => {
+    const onClick = vi.fn();
+    render(<ClozeSubmitButton disabled={true} label="OK" onClick={onClick} />);
 
-        const btn = screen.getByRole("button", { name: "OK" });
-        expect(btn).toBeDisabled();
+    const btn = screen.getByRole("button", { name: "OK" });
+    expect(btn).toBeDisabled();
 
-        fireEvent.click(btn);
-        expect(onClick).not.toHaveBeenCalled();
-    });
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/tests/components/cloze-exercise/ClozeSubmitButton.test.tsx
+++ b/frontend/tests/components/cloze-exercise/ClozeSubmitButton.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import ClozeSubmitButton from "@/components/ui_elements/cloze_exercise/ClozeSubmitButton";
+
+describe("ClozeSubmitButton", () => {
+    it("rendert das übergebene Label", () => {
+        render(<ClozeSubmitButton disabled={false} label="Prüfen" onClick={() => { }} />);
+        expect(screen.getByRole("button", { name: "Prüfen" })).toBeInTheDocument();
+    });
+
+    it("ruft onClick auf, wenn enabled", () => {
+        const onClick = vi.fn();
+        render(<ClozeSubmitButton disabled={false} label="OK" onClick={onClick} />);
+
+        fireEvent.click(screen.getByRole("button", { name: "OK" }));
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("ruft onClick NICHT auf, wenn disabled", () => {
+        const onClick = vi.fn();
+        render(<ClozeSubmitButton disabled={true} label="OK" onClick={onClick} />);
+
+        const btn = screen.getByRole("button", { name: "OK" });
+        expect(btn).toBeDisabled();
+
+        fireEvent.click(btn);
+        expect(onClick).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/tests/components/cloze-exercise/SolutionWordBank.test.tsx
+++ b/frontend/tests/components/cloze-exercise/SolutionWordBank.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import SolutionWordBank, { SolutionWord } from "@/components/ui_elements/cloze_exercise/SolutionWordBank";
+
+// Helfer für DataTransfer
+function createDataTransfer(initial: Record<string, string> = {}) {
+    const store = { ...initial };
+    return {
+        setData: vi.fn((key: string, val: string) => { store[key] = val; }),
+        getData: vi.fn((key: string) => store[key]),
+        dropEffect: "move",
+        effectAllowed: "all",
+        files: [],
+        items: [],
+        types: Object.keys(store),
+    } as unknown as DataTransfer;
+}
+
+const words: SolutionWord[] = [
+    { id: "w1", word: "Haus", available: true },
+    { id: "w2", word: "Baum", available: false },
+];
+
+describe("SolutionWordBank", () => {
+    it("rendert alle Wörter und markiert data-testid='solution-words' auf dem Container", () => {
+        render(
+            <SolutionWordBank
+                words={words}
+                onReturnToBank={vi.fn()}
+                onQuickPlace={vi.fn()}
+            />
+        );
+        expect(screen.getByTestId("solution-words")).toBeInTheDocument();
+        expect(screen.getByText("Haus")).toBeInTheDocument();
+        expect(screen.getByText("Baum")).toBeInTheDocument();
+    });
+
+    it("Ctrl/Cmd-Klick auf verfügbares Wort ruft onQuickPlace mit word.id auf", () => {
+        const onQuickPlace = vi.fn();
+        render(
+            <SolutionWordBank
+                words={words}
+                onReturnToBank={vi.fn()}
+                onQuickPlace={onQuickPlace}
+            />
+        );
+
+        const haus = screen.getByText("Haus");
+        fireEvent.click(haus, { ctrlKey: true });
+
+        expect(onQuickPlace).toHaveBeenCalledTimes(1);
+        expect(onQuickPlace).toHaveBeenCalledWith("w1");
+    });
+
+    it("Ctrl/Cmd-Klick auf NICHT verfügbares Wort macht nichts", () => {
+        const onQuickPlace = vi.fn();
+        render(
+            <SolutionWordBank
+                words={words}
+                onReturnToBank={vi.fn()}
+                onQuickPlace={onQuickPlace}
+            />
+        );
+
+        const baum = screen.getByText("Baum");
+        fireEvent.click(baum, { metaKey: true }); // macOS-Variante
+
+        expect(onQuickPlace).not.toHaveBeenCalled();
+    });
+
+    it("Drop auf den Container ruft onReturnToBank mit wordId aus dataTransfer auf", () => {
+        const onReturnToBank = vi.fn();
+        render(
+            <SolutionWordBank
+                words={words}
+                onReturnToBank={onReturnToBank}
+                onQuickPlace={vi.fn()}
+            />
+        );
+
+        const container = screen.getByTestId("solution-words");
+        const dt = createDataTransfer({ wordId: "w2" });
+
+        fireEvent.dragOver(container, { dataTransfer: dt }); // damit drop akzeptiert wird
+        fireEvent.drop(container, { dataTransfer: dt });
+
+        expect(onReturnToBank).toHaveBeenCalledTimes(1);
+        expect(onReturnToBank).toHaveBeenCalledWith("w2");
+    });
+
+    it("Drop ohne wordId triggert onReturnToBank NICHT (Edge Case)", () => {
+        const onReturnToBank = vi.fn();
+        render(
+            <SolutionWordBank
+                words={words}
+                onReturnToBank={onReturnToBank}
+                onQuickPlace={vi.fn()}
+            />
+        );
+
+        const container = screen.getByTestId("solution-words");
+        const dt = createDataTransfer(); // leer
+
+        fireEvent.dragOver(container, { dataTransfer: dt });
+        fireEvent.drop(container, { dataTransfer: dt });
+
+        expect(onReturnToBank).not.toHaveBeenCalled();
+    });
+
+    it("setzt draggable nur bei verfügbaren Wörtern", () => {
+        render(
+            <SolutionWordBank
+                words={words}
+                onReturnToBank={vi.fn()}
+                onQuickPlace={vi.fn()}
+            />
+        );
+
+        const haus = screen.getByText("Haus");
+        const baum = screen.getByText("Baum");
+
+        // HTMLElement-Attribut 'draggable' ist ein String-Attribut im DOM
+        expect(haus).toHaveAttribute("draggable", "true");
+        expect(baum).toHaveAttribute("draggable", "false");
+    });
+
+    it("dragStart setzt dataTransfer.wordId nur bei verfügbaren Wörtern (implizit durch Handler-Gate)", () => {
+        render(
+            <SolutionWordBank
+                words={words}
+                onReturnToBank={vi.fn()}
+                onQuickPlace={vi.fn()}
+            />
+        );
+
+        const dt = createDataTransfer();
+        const haus = screen.getByText("Haus");
+        fireEvent.dragStart(haus, { dataTransfer: dt });
+
+        expect(dt.setData).toHaveBeenCalledWith("wordId", "w1");
+
+        const dt2 = createDataTransfer();
+        const baum = screen.getByText("Baum");
+        // bei nicht verfügbaren gibt es zwar ein dragStart Event, aber das Element hat draggable=false,
+        // Browser feuern i.d.R. kein echtes dragStart. Zur Sicherheit: unser Handler ist durch word.available gegated.
+        fireEvent.dragStart(baum, { dataTransfer: dt2 });
+
+        // keine SetData-Aufrufe für das nicht verfügbare Wort
+        expect(dt2.setData).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/tests/components/cloze-exercise/SolutionWordBank.test.tsx
+++ b/frontend/tests/components/cloze-exercise/SolutionWordBank.test.tsx
@@ -1,152 +1,156 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
-import SolutionWordBank, { SolutionWord } from "@/components/ui_elements/cloze_exercise/SolutionWordBank";
+import SolutionWordBank, {
+  SolutionWord,
+} from "@/components/ui_elements/cloze_exercise/SolutionWordBank";
 
 // Helfer für DataTransfer
 function createDataTransfer(initial: Record<string, string> = {}) {
-    const store = { ...initial };
-    return {
-        setData: vi.fn((key: string, val: string) => { store[key] = val; }),
-        getData: vi.fn((key: string) => store[key]),
-        dropEffect: "move",
-        effectAllowed: "all",
-        files: [],
-        items: [],
-        types: Object.keys(store),
-    } as unknown as DataTransfer;
+  const store = { ...initial };
+  return {
+    setData: vi.fn((key: string, val: string) => {
+      store[key] = val;
+    }),
+    getData: vi.fn((key: string) => store[key]),
+    dropEffect: "move",
+    effectAllowed: "all",
+    files: [],
+    items: [],
+    types: Object.keys(store),
+  } as unknown as DataTransfer;
 }
 
 const words: SolutionWord[] = [
-    { id: "w1", word: "Haus", available: true },
-    { id: "w2", word: "Baum", available: false },
+  { id: "w1", word: "Haus", available: true },
+  { id: "w2", word: "Baum", available: false },
 ];
 
 describe("SolutionWordBank", () => {
-    it("rendert alle Wörter und markiert data-testid='solution-words' auf dem Container", () => {
-        render(
-            <SolutionWordBank
-                words={words}
-                onReturnToBank={vi.fn()}
-                onQuickPlace={vi.fn()}
-            />
-        );
-        expect(screen.getByTestId("solution-words")).toBeInTheDocument();
-        expect(screen.getByText("Haus")).toBeInTheDocument();
-        expect(screen.getByText("Baum")).toBeInTheDocument();
-    });
+  it("rendert alle Wörter und markiert data-testid='solution-words' auf dem Container", () => {
+    render(
+      <SolutionWordBank
+        words={words}
+        onReturnToBank={vi.fn()}
+        onQuickPlace={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("solution-words")).toBeInTheDocument();
+    expect(screen.getByText("Haus")).toBeInTheDocument();
+    expect(screen.getByText("Baum")).toBeInTheDocument();
+  });
 
-    it("Ctrl/Cmd-Klick auf verfügbares Wort ruft onQuickPlace mit word.id auf", () => {
-        const onQuickPlace = vi.fn();
-        render(
-            <SolutionWordBank
-                words={words}
-                onReturnToBank={vi.fn()}
-                onQuickPlace={onQuickPlace}
-            />
-        );
+  it("Ctrl/Cmd-Klick auf verfügbares Wort ruft onQuickPlace mit word.id auf", () => {
+    const onQuickPlace = vi.fn();
+    render(
+      <SolutionWordBank
+        words={words}
+        onReturnToBank={vi.fn()}
+        onQuickPlace={onQuickPlace}
+      />,
+    );
 
-        const haus = screen.getByText("Haus");
-        fireEvent.click(haus, { ctrlKey: true });
+    const haus = screen.getByText("Haus");
+    fireEvent.click(haus, { ctrlKey: true });
 
-        expect(onQuickPlace).toHaveBeenCalledTimes(1);
-        expect(onQuickPlace).toHaveBeenCalledWith("w1");
-    });
+    expect(onQuickPlace).toHaveBeenCalledTimes(1);
+    expect(onQuickPlace).toHaveBeenCalledWith("w1");
+  });
 
-    it("Ctrl/Cmd-Klick auf NICHT verfügbares Wort macht nichts", () => {
-        const onQuickPlace = vi.fn();
-        render(
-            <SolutionWordBank
-                words={words}
-                onReturnToBank={vi.fn()}
-                onQuickPlace={onQuickPlace}
-            />
-        );
+  it("Ctrl/Cmd-Klick auf NICHT verfügbares Wort macht nichts", () => {
+    const onQuickPlace = vi.fn();
+    render(
+      <SolutionWordBank
+        words={words}
+        onReturnToBank={vi.fn()}
+        onQuickPlace={onQuickPlace}
+      />,
+    );
 
-        const baum = screen.getByText("Baum");
-        fireEvent.click(baum, { metaKey: true }); // macOS-Variante
+    const baum = screen.getByText("Baum");
+    fireEvent.click(baum, { metaKey: true }); // macOS-Variante
 
-        expect(onQuickPlace).not.toHaveBeenCalled();
-    });
+    expect(onQuickPlace).not.toHaveBeenCalled();
+  });
 
-    it("Drop auf den Container ruft onReturnToBank mit wordId aus dataTransfer auf", () => {
-        const onReturnToBank = vi.fn();
-        render(
-            <SolutionWordBank
-                words={words}
-                onReturnToBank={onReturnToBank}
-                onQuickPlace={vi.fn()}
-            />
-        );
+  it("Drop auf den Container ruft onReturnToBank mit wordId aus dataTransfer auf", () => {
+    const onReturnToBank = vi.fn();
+    render(
+      <SolutionWordBank
+        words={words}
+        onReturnToBank={onReturnToBank}
+        onQuickPlace={vi.fn()}
+      />,
+    );
 
-        const container = screen.getByTestId("solution-words");
-        const dt = createDataTransfer({ wordId: "w2" });
+    const container = screen.getByTestId("solution-words");
+    const dt = createDataTransfer({ wordId: "w2" });
 
-        fireEvent.dragOver(container, { dataTransfer: dt }); // damit drop akzeptiert wird
-        fireEvent.drop(container, { dataTransfer: dt });
+    fireEvent.dragOver(container, { dataTransfer: dt }); // damit drop akzeptiert wird
+    fireEvent.drop(container, { dataTransfer: dt });
 
-        expect(onReturnToBank).toHaveBeenCalledTimes(1);
-        expect(onReturnToBank).toHaveBeenCalledWith("w2");
-    });
+    expect(onReturnToBank).toHaveBeenCalledTimes(1);
+    expect(onReturnToBank).toHaveBeenCalledWith("w2");
+  });
 
-    it("Drop ohne wordId triggert onReturnToBank NICHT (Edge Case)", () => {
-        const onReturnToBank = vi.fn();
-        render(
-            <SolutionWordBank
-                words={words}
-                onReturnToBank={onReturnToBank}
-                onQuickPlace={vi.fn()}
-            />
-        );
+  it("Drop ohne wordId triggert onReturnToBank NICHT (Edge Case)", () => {
+    const onReturnToBank = vi.fn();
+    render(
+      <SolutionWordBank
+        words={words}
+        onReturnToBank={onReturnToBank}
+        onQuickPlace={vi.fn()}
+      />,
+    );
 
-        const container = screen.getByTestId("solution-words");
-        const dt = createDataTransfer(); // leer
+    const container = screen.getByTestId("solution-words");
+    const dt = createDataTransfer(); // leer
 
-        fireEvent.dragOver(container, { dataTransfer: dt });
-        fireEvent.drop(container, { dataTransfer: dt });
+    fireEvent.dragOver(container, { dataTransfer: dt });
+    fireEvent.drop(container, { dataTransfer: dt });
 
-        expect(onReturnToBank).not.toHaveBeenCalled();
-    });
+    expect(onReturnToBank).not.toHaveBeenCalled();
+  });
 
-    it("setzt draggable nur bei verfügbaren Wörtern", () => {
-        render(
-            <SolutionWordBank
-                words={words}
-                onReturnToBank={vi.fn()}
-                onQuickPlace={vi.fn()}
-            />
-        );
+  it("setzt draggable nur bei verfügbaren Wörtern", () => {
+    render(
+      <SolutionWordBank
+        words={words}
+        onReturnToBank={vi.fn()}
+        onQuickPlace={vi.fn()}
+      />,
+    );
 
-        const haus = screen.getByText("Haus");
-        const baum = screen.getByText("Baum");
+    const haus = screen.getByText("Haus");
+    const baum = screen.getByText("Baum");
 
-        // HTMLElement-Attribut 'draggable' ist ein String-Attribut im DOM
-        expect(haus).toHaveAttribute("draggable", "true");
-        expect(baum).toHaveAttribute("draggable", "false");
-    });
+    // HTMLElement-Attribut 'draggable' ist ein String-Attribut im DOM
+    expect(haus).toHaveAttribute("draggable", "true");
+    expect(baum).toHaveAttribute("draggable", "false");
+  });
 
-    it("dragStart setzt dataTransfer.wordId nur bei verfügbaren Wörtern (implizit durch Handler-Gate)", () => {
-        render(
-            <SolutionWordBank
-                words={words}
-                onReturnToBank={vi.fn()}
-                onQuickPlace={vi.fn()}
-            />
-        );
+  it("dragStart setzt dataTransfer.wordId nur bei verfügbaren Wörtern (implizit durch Handler-Gate)", () => {
+    render(
+      <SolutionWordBank
+        words={words}
+        onReturnToBank={vi.fn()}
+        onQuickPlace={vi.fn()}
+      />,
+    );
 
-        const dt = createDataTransfer();
-        const haus = screen.getByText("Haus");
-        fireEvent.dragStart(haus, { dataTransfer: dt });
+    const dt = createDataTransfer();
+    const haus = screen.getByText("Haus");
+    fireEvent.dragStart(haus, { dataTransfer: dt });
 
-        expect(dt.setData).toHaveBeenCalledWith("wordId", "w1");
+    expect(dt.setData).toHaveBeenCalledWith("wordId", "w1");
 
-        const dt2 = createDataTransfer();
-        const baum = screen.getByText("Baum");
-        // bei nicht verfügbaren gibt es zwar ein dragStart Event, aber das Element hat draggable=false,
-        // Browser feuern i.d.R. kein echtes dragStart. Zur Sicherheit: unser Handler ist durch word.available gegated.
-        fireEvent.dragStart(baum, { dataTransfer: dt2 });
+    const dt2 = createDataTransfer();
+    const baum = screen.getByText("Baum");
+    // bei nicht verfügbaren gibt es zwar ein dragStart Event, aber das Element hat draggable=false,
+    // Browser feuern i.d.R. kein echtes dragStart. Zur Sicherheit: unser Handler ist durch word.available gegated.
+    fireEvent.dragStart(baum, { dataTransfer: dt2 });
 
-        // keine SetData-Aufrufe für das nicht verfügbare Wort
-        expect(dt2.setData).not.toHaveBeenCalled();
-    });
+    // keine SetData-Aufrufe für das nicht verfügbare Wort
+    expect(dt2.setData).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Lückentext-Komponente mit 2 Modi:
1. Liste an Lösungswörtern über dem Text, die per Drag & Drop eingesetzt werden:
- Es ist möglich, auch inkorrekte Wörter in der liste anzuzeigen
- Mit Ctrl+ Click kann ein Wort in die erste freie Lücke teleportiert werden

2. Freitexteingabe

Bei Klick auf Prüfen erscheint Feedback bzgl. Erfolg oder Anzahl an Fehler