### PR TITLE
Rework/ccs-123-modulübersicht 

### DIFF
--- a/frontend/src/components/cards/card_modules_small.tsx
+++ b/frontend/src/components/cards/card_modules_small.tsx
@@ -59,9 +59,9 @@ const CardModulesSmall: React.FC<CardModulesSmallProps> = ({
           <h3
             title={title}
             className={clsx(
-              "font-semibold text-gray-900 text-base leading-tight",
-              "group-hover:text-dsp-orange transition-colors duration-300",
-              "line-clamp-2"
+                "ds-title leading-tight",
+                "group-hover:text-dsp-orange transition-colors duration-300",
+                "line-clamp-2"
             )}
           >
             {title}

--- a/frontend/src/components/cards/card_modules_small.tsx
+++ b/frontend/src/components/cards/card_modules_small.tsx
@@ -70,19 +70,20 @@ const CardModulesSmall: React.FC<CardModulesSmallProps> = ({
     <motion.div
       className={clsx(
         // Base professional styling
-        "group relative",
-        "bg-white/90 backdrop-blur-sm",
+          "group relative overflow-hidden isolate",
+        "bg-white",
         "border border-gray-200/60",
         "rounded-xl p-4",
         "shadow-sm hover:shadow-md",
         "transition-all duration-200 ease-in-out",
-        "cursor-pointer",
+        "cursor-pointer hover:z-10",
+        "h-40",
         config.borderHover,
         config.hoverBg,
         className,
       )}
       onClick={onClick}
-      whileHover={{ y: -1, scale: 1.01 }}
+      whileHover={{ y: -2 }}
       whileTap={{ scale: 0.99 }}
       transition={{ duration: 0.15 }}
     >
@@ -102,21 +103,24 @@ const CardModulesSmall: React.FC<CardModulesSmallProps> = ({
         </motion.div>
 
         {/* Content Area */}
-        <div className="flex-grow min-w-0">
+        <div className="flex-grow min-w-0 flex flex-col">
           {/* Header with title and difficulty */}
           <div className="flex items-start justify-between mb-2">
             <h3
-              className={clsx(
-                "font-semibold text-gray-900 text-sm leading-tight",
-                "group-hover:text-dsp-orange transition-colors duration-200",
-                "line-clamp-1 flex-1 pr-2",
-              )}
+                title={title}
+                className={clsx(
+                    "font-semibold text-gray-900 text-sm leading-tight",
+                    "group-hover:text-dsp-orange transition-colors duration-200",
+                    "line-clamp-2 flex-1 pr-2",
+                    )}
             >
               {title}
             </h3>
 
             <div className="flex-shrink-0">{difficultyTag}</div>
           </div>
+
+            <div className="flex-1" />
 
           {/* Professional Progress Section */}
           <div className="space-y-2">
@@ -162,7 +166,7 @@ const CardModulesSmall: React.FC<CardModulesSmallProps> = ({
       </div>
 
       {/* Subtle hover glow */}
-      <div className="absolute inset-0 rounded-xl bg-gradient-to-br from-dsp-orange/3 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none" />
+      <div className="absolute inset-0 rounded-xl bg-gradient-to-br from-dsp-orange/5 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none" />
 
       {/* Professional border highlight on hover */}
       <div className="absolute inset-0 rounded-xl border border-transparent group-hover:border-dsp-orange/20 transition-colors duration-200 pointer-events-none" />

--- a/frontend/src/components/cards/card_modules_small.tsx
+++ b/frontend/src/components/cards/card_modules_small.tsx
@@ -1,18 +1,14 @@
-import React from "react";
 import clsx from "clsx";
 import { motion } from "framer-motion";
-import {
-  IoCheckmarkOutline,
-  IoHourglassOutline,
-  IoPlayOutline,
-} from "react-icons/io5";
+import { IoPlay } from "react-icons/io5";
+import type { ReactNode } from "react";
 
 type ModuleStatus = "Nicht begonnen" | "In Bearbeitung" | "Abgeschlossen";
 
 interface CardModulesSmallProps {
   title: string;
   progress: number;
-  difficultyTag: React.ReactNode;
+  difficultyTag: ReactNode;
   className?: string;
   onClick?: () => void;
 }
@@ -31,145 +27,109 @@ const CardModulesSmall: React.FC<CardModulesSmallProps> = ({
         ? "In Bearbeitung"
         : "Nicht begonnen";
 
-  const getStatusConfig = (s: ModuleStatus) => {
-    switch (s) {
-      case "Abgeschlossen":
-        return {
-          icon: <IoCheckmarkOutline className="h-4 w-4 text-white" />,
-          iconBgColor: "bg-green-500",
-          progressColor: "bg-green-500",
-          statusColor: "text-green-600",
-          hoverBg: "hover:bg-green-50",
-          borderHover: "hover:border-green-200",
-        };
-      case "In Bearbeitung":
-        return {
-          icon: <IoHourglassOutline className="h-4 w-4 text-white" />,
-          iconBgColor: "bg-dsp-orange",
-          progressColor: "bg-dsp-orange",
-          statusColor: "text-dsp-orange",
-          hoverBg: "hover:bg-dsp-orange_light",
-          borderHover: "hover:border-dsp-orange/30",
-        };
-      case "Nicht begonnen":
-      default:
-        return {
-          icon: <IoPlayOutline className="h-4 w-4 text-gray-600" />,
-          iconBgColor: "bg-gray-200",
-          progressColor: "bg-gray-300",
-          statusColor: "text-gray-600",
-          hoverBg: "hover:bg-gray-50",
-          borderHover: "hover:border-gray-300",
-        };
-    }
-  };
-
-  const config = getStatusConfig(derivedStatus);
+  const statusColor =
+      derivedStatus === "Abgeschlossen"
+          ? "text-green-600"
+          : derivedStatus === "In Bearbeitung"
+          ? "text-dsp-orange"
+          : "text-gray-600";
 
   return (
     <motion.div
       className={clsx(
-        // Base professional styling
-          "group relative overflow-hidden isolate",
-        "bg-white",
-        "border border-gray-200/60",
-        "rounded-xl p-4",
-        "shadow-sm hover:shadow-md",
-        "transition-all duration-200 ease-in-out",
-        "cursor-pointer hover:z-10",
-        "h-40",
-        config.borderHover,
-        config.hoverBg,
-        className,
+        "group relative overflow-hidden isolate",
+          "rounded-xl p-4 h-40 flex flex-col",
+          "border border-gray-200/50",
+          "bg-gradient-to-br from-white via-white/98 to-white/95",
+          "transition-all duration-500 hover:border-dsp-orange/30 hover:shadow-[0_12px_30px_-10px_rgba(0,0,0,0.25)]",
+          "cursor-pointer",
+          className
       )}
       onClick={onClick}
       whileHover={{ y: -2 }}
       whileTap={{ scale: 0.99 }}
       transition={{ duration: 0.15 }}
     >
-      {/* Content Layout */}
-      <div className="flex items-center gap-4">
-        {/* Status Icon */}
-        <motion.div
-          className={clsx(
-            "flex-shrink-0 w-10 h-10 rounded-xl flex items-center justify-center",
-            "shadow-sm border border-white/20",
-            config.iconBgColor,
-          )}
-          whileHover={{ rotate: 5 }}
-          transition={{ duration: 0.2 }}
-        >
-          {config.icon}
-        </motion.div>
+        {/* Hover gradient + glow */}
+        <div className="absolute inset-0 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity duration-500 bg-gradient-to-br from-dsp-orange/5 via-transparent to-emerald-400/5" />
+        <div className="absolute -inset-0.5 rounded-xl -z-10 pointer-events-none opacity-0 group-hover:opacity-100 blur-xl transition-all duration-500 bg-gradient-to-br from-dsp-orange/20 to-emerald-400/20" />
 
-        {/* Content Area */}
-        <div className="flex-grow min-w-0 flex flex-col">
-          {/* Header with title and difficulty */}
-          <div className="flex items-start justify-between mb-2">
-            <h3
-                title={title}
+        {/* Header row */}
+        <div className="flex items-start justify-between gap-3">
+          <h3
+            title={title}
+            className={clsx(
+              "font-semibold text-gray-900 text-base leading-tight",
+              "group-hover:text-dsp-orange transition-colors duration-300",
+              "line-clamp-2"
+            )}
+          >
+            {title}
+          </h3>
+          {/* Play button */}
+          <button
+            className="shrink-0 h-10 w-10 rounded-full bg-gray-100 hover:bg-dsp-orange hover:text-white transition-all duration-300 grid place-items-center shadow-sm"
+            aria-label="Starten"
+            type="button"
+          >
+            <IoPlay className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Optional difficulty pill */}
+        {difficultyTag && <div className="mt-2">{difficultyTag}</div>}
+
+        <div className="flex-1" />
+
+        {/* Status + progress */}
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span
                 className={clsx(
-                    "font-semibold text-gray-900 text-sm leading-tight",
-                    "group-hover:text-dsp-orange transition-colors duration-200",
-                    "line-clamp-2 flex-1 pr-2",
-                    )}
-            >
-              {title}
-            </h3>
-
-            <div className="flex-shrink-0">{difficultyTag}</div>
-          </div>
-
-            <div className="flex-1" />
-
-          {/* Professional Progress Section */}
-          <div className="space-y-2">
-            {/* Progress info */}
-            <div className="flex items-center justify-between">
-              <span className={clsx("text-xs font-medium", config.statusColor)}>
+                  "relative inline-flex h-3 w-3 rounded-full",
+                  derivedStatus === "Abgeschlossen"
+                    ? "bg-green-600"
+                    : derivedStatus === "In Bearbeitung"
+                    ? "bg-dsp-orange"
+                    : "bg-gray-400",
+                )}
+              >
+                {derivedStatus === "In Bearbeitung" && (
+                  <span className="absolute inset-0 rounded-full animate-ping opacity-75 bg-dsp-orange" />
+                )}
+              </span>
+              <span className={clsx("text-xs font-medium", statusColor)}>
                 {derivedStatus}
               </span>
-              <span
-                className={clsx("text-xs font-semibold", config.statusColor)}
-              >
-                {progress}%
-              </span>
             </div>
-
-            {/* Enhanced progress bar */}
-            <div className="relative">
-              <div className="w-full bg-gray-200 rounded-full h-1.5 overflow-hidden">
-                <motion.div
-                  className={clsx(
-                    "h-1.5 rounded-full transition-all duration-300",
-                    config.progressColor,
-                  )}
-                  initial={{ width: 0 }}
-                  animate={{ width: `${progress}%` }}
-                  transition={{ duration: 0.8, ease: "easeOut" }}
-                />
-              </div>
-
-              {/* Progress glow effect */}
-              {progress > 0 && (
-                <div
-                  className={clsx(
-                    "absolute top-0 left-0 h-1.5 rounded-full opacity-40 blur-sm",
-                    config.progressColor,
-                  )}
-                  style={{ width: `${Math.min(progress, 100)}%` }}
-                />
+            <span
+              className={clsx(
+                "text-xs font-semibold",
+                statusColor,
+                "bg-gray-100 px-2 py-0.5 rounded-md",
               )}
+            >
+              {Math.round(progress)}%
+            </span>
+          </div>
+
+          {/* Gradient progress bar */}
+          <div className="relative">
+            <div className="w-full bg-gray-200 rounded-full h-2.5 overflow-hidden shadow-inner">
+              <motion.div
+                className="h-full rounded-full transition-all duration-700 ease-out relative overflow-hidden bg-gradient-to-r from-dsp-orange via-orange-300 to-emerald-400"
+                initial={{ width: 0 }}
+                animate={{ width: `${Math.min(Math.max(progress, 0), 100)}%` }}
+              >
+                <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/40 to-transparent animate-pulse" />
+              </motion.div>
             </div>
           </div>
         </div>
-      </div>
 
-      {/* Subtle hover glow */}
-      <div className="absolute inset-0 rounded-xl bg-gradient-to-br from-dsp-orange/5 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none" />
 
-      {/* Professional border highlight on hover */}
-      <div className="absolute inset-0 rounded-xl border border-transparent group-hover:border-dsp-orange/20 transition-colors duration-200 pointer-events-none" />
+       {/* (Glow handled by the two gradient layers at the top) */}
     </motion.div>
   );
 };

--- a/frontend/src/components/cards/card_modules_small.tsx
+++ b/frontend/src/components/cards/card_modules_small.tsx
@@ -28,108 +28,107 @@ const CardModulesSmall: React.FC<CardModulesSmallProps> = ({
         : "Nicht begonnen";
 
   const statusColor =
-      derivedStatus === "Abgeschlossen"
-          ? "text-green-600"
-          : derivedStatus === "In Bearbeitung"
-          ? "text-dsp-orange"
-          : "text-gray-600";
+    derivedStatus === "Abgeschlossen"
+      ? "text-green-600"
+      : derivedStatus === "In Bearbeitung"
+        ? "text-dsp-orange"
+        : "text-gray-600";
 
   return (
     <motion.div
       className={clsx(
         "group relative overflow-hidden isolate",
-          "rounded-xl p-4 h-40 flex flex-col",
-          "border border-gray-200/50",
-          "bg-gradient-to-br from-white via-white/98 to-white/95",
-          "transition-all duration-500 hover:border-dsp-orange/30 hover:shadow-[0_12px_30px_-10px_rgba(0,0,0,0.25)]",
-          "cursor-pointer",
-          className
+        "rounded-xl p-4 h-40 flex flex-col",
+        "border border-gray-200/50",
+        "bg-gradient-to-br from-white via-white/98 to-white/95",
+        "transition-all duration-500 hover:border-dsp-orange/30 hover:shadow-[0_12px_30px_-10px_rgba(0,0,0,0.25)]",
+        "cursor-pointer",
+        className,
       )}
       onClick={onClick}
       whileHover={{ y: -2 }}
       whileTap={{ scale: 0.99 }}
       transition={{ duration: 0.15 }}
     >
-        {/* Hover gradient + glow */}
-        <div className="absolute inset-0 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity duration-500 bg-gradient-to-br from-dsp-orange/5 via-transparent to-emerald-400/5" />
-        <div className="absolute -inset-0.5 rounded-xl -z-10 pointer-events-none opacity-0 group-hover:opacity-100 blur-xl transition-all duration-500 bg-gradient-to-br from-dsp-orange/20 to-emerald-400/20" />
+      {/* Hover gradient + glow */}
+      <div className="absolute inset-0 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity duration-500 bg-gradient-to-br from-dsp-orange/5 via-transparent to-emerald-400/5" />
+      <div className="absolute -inset-0.5 rounded-xl -z-10 pointer-events-none opacity-0 group-hover:opacity-100 blur-xl transition-all duration-500 bg-gradient-to-br from-dsp-orange/20 to-emerald-400/20" />
 
-        {/* Header row */}
-        <div className="flex items-start justify-between gap-3">
-          <h3
-            title={title}
-            className={clsx(
-                "ds-title leading-tight",
-                "group-hover:text-dsp-orange transition-colors duration-300",
-                "line-clamp-2"
-            )}
-          >
-            {title}
-          </h3>
-          {/* Play button */}
-          <button
-            className="shrink-0 h-10 w-10 rounded-full bg-gray-100 hover:bg-dsp-orange hover:text-white transition-all duration-300 grid place-items-center shadow-sm"
-            aria-label="Starten"
-            type="button"
-          >
-            <IoPlay className="h-5 w-5" />
-          </button>
-        </div>
+      {/* Header row */}
+      <div className="flex items-start justify-between gap-3">
+        <h3
+          title={title}
+          className={clsx(
+            "ds-title leading-tight",
+            "group-hover:text-dsp-orange transition-colors duration-300",
+            "line-clamp-2",
+          )}
+        >
+          {title}
+        </h3>
+        {/* Play button */}
+        <button
+          className="shrink-0 h-10 w-10 rounded-full bg-gray-100 hover:bg-dsp-orange hover:text-white transition-all duration-300 grid place-items-center shadow-sm"
+          aria-label="Starten"
+          type="button"
+        >
+          <IoPlay className="h-5 w-5" />
+        </button>
+      </div>
 
-        {/* Optional difficulty pill */}
-        {difficultyTag && <div className="mt-2">{difficultyTag}</div>}
+      {/* Optional difficulty pill */}
+      {difficultyTag && <div className="mt-2">{difficultyTag}</div>}
 
-        <div className="flex-1" />
+      <div className="flex-1" />
 
-        {/* Status + progress */}
-        <div className="space-y-2">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <span
-                className={clsx(
-                  "relative inline-flex h-3 w-3 rounded-full",
-                  derivedStatus === "Abgeschlossen"
-                    ? "bg-green-600"
-                    : derivedStatus === "In Bearbeitung"
-                    ? "bg-dsp-orange"
-                    : "bg-gray-400",
-                )}
-              >
-                {derivedStatus === "In Bearbeitung" && (
-                  <span className="absolute inset-0 rounded-full animate-ping opacity-75 bg-dsp-orange" />
-                )}
-              </span>
-              <span className={clsx("text-xs font-medium", statusColor)}>
-                {derivedStatus}
-              </span>
-            </div>
+      {/* Status + progress */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
             <span
               className={clsx(
-                "text-xs font-semibold",
-                statusColor,
-                "bg-gray-100 px-2 py-0.5 rounded-md",
+                "relative inline-flex h-3 w-3 rounded-full",
+                derivedStatus === "Abgeschlossen"
+                  ? "bg-green-600"
+                  : derivedStatus === "In Bearbeitung"
+                    ? "bg-dsp-orange"
+                    : "bg-gray-400",
               )}
             >
-              {Math.round(progress)}%
+              {derivedStatus === "In Bearbeitung" && (
+                <span className="absolute inset-0 rounded-full animate-ping opacity-75 bg-dsp-orange" />
+              )}
+            </span>
+            <span className={clsx("text-xs font-medium", statusColor)}>
+              {derivedStatus}
             </span>
           </div>
-
-          {/* Gradient progress bar */}
-          <div className="relative">
-            <div className="w-full bg-gray-200 rounded-full h-2.5 overflow-hidden shadow-inner">
-              <motion.div
-                className="h-full rounded-full transition-all duration-700 ease-out relative overflow-hidden bg-gradient-to-r from-dsp-orange via-orange-300 to-emerald-400"
-                initial={{ width: 0 }}
-                animate={{ width: `${Math.min(Math.max(progress, 0), 100)}%` }}
-              >
-                <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/40 to-transparent animate-pulse" />
-              </motion.div>
-            </div>
-          </div>
+          <span
+            className={clsx(
+              "text-xs font-semibold",
+              statusColor,
+              "bg-gray-100 px-2 py-0.5 rounded-md",
+            )}
+          >
+            {Math.round(progress)}%
+          </span>
         </div>
 
+        {/* Gradient progress bar */}
+        <div className="relative">
+          <div className="w-full bg-gray-200 rounded-full h-2.5 overflow-hidden shadow-inner">
+            <motion.div
+              className="h-full rounded-full transition-all duration-700 ease-out relative overflow-hidden bg-gradient-to-r from-dsp-orange via-orange-300 to-emerald-400"
+              initial={{ width: 0 }}
+              animate={{ width: `${Math.min(Math.max(progress, 0), 100)}%` }}
+            >
+              <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/40 to-transparent animate-pulse" />
+            </motion.div>
+          </div>
+        </div>
+      </div>
 
-       {/* (Glow handled by the two gradient layers at the top) */}
+      {/* (Glow handled by the two gradient layers at the top) */}
     </motion.div>
   );
 };

--- a/frontend/src/components/cards/card_preview_small.tsx
+++ b/frontend/src/components/cards/card_preview_small.tsx
@@ -82,13 +82,13 @@ const CardPreviewSmall: React.FC<CardPreviewSmallProps> = ({
     <motion.div
       className={clsx(
         // Base card styling - professional SaaS look
-        "relative group cursor-pointer",
-        "bg-white/90 backdrop-blur-sm",
+        "relative group cursor-pointer isolate",
+        "bg-white",
         "border border-gray-200/60 hover:border-dsp-orange/30",
-        "rounded-xl overflow-hidden",
+        "rounded-xl overflow-hidden h-40 flex flex-col",
         "shadow-sm hover:shadow-md",
         "transition-all duration-200 ease-in-out",
-        "hover:scale-[1.02] hover:-translate-y-1",
+        "hover:-translate-y-1 hover:z-10",
         className,
       )}
       onClick={onClick}
@@ -99,7 +99,7 @@ const CardPreviewSmall: React.FC<CardPreviewSmallProps> = ({
       {displayImage && (
         <div
           className={clsx(
-            "relative w-full aspect-video overflow-hidden",
+            "relative w-full h-24 overflow-hidden flex-shrink-0",
             "bg-gradient-to-br from-gray-100 to-gray-200",
             classNameImage,
           )}
@@ -133,9 +133,9 @@ const CardPreviewSmall: React.FC<CardPreviewSmallProps> = ({
       )}
 
       {/* Professional Content Area */}
-      <div className={clsx("p-4", classNameContentWrapper)}>
+      <div className={clsx("p-4 flex-1 flex flex-col", classNameContentWrapper)}>
         {/* Title Section */}
-        <div className="mb-3">
+         <div className="mb-3">
           <h3
             className={clsx(
               "font-semibold text-gray-900 text-base leading-tight",

--- a/frontend/src/components/cards/card_preview_small.tsx
+++ b/frontend/src/components/cards/card_preview_small.tsx
@@ -1,13 +1,10 @@
-import React from "react";
+import React, { type ReactNode } from "react";
 import { motion } from "framer-motion";
-import {
-  IoPlayCircleOutline,
-  IoCheckmarkCircleOutline,
-  IoTimeOutline,
-} from "react-icons/io5";
+import { IoPlay } from "react-icons/io5";
 import clsx from "clsx";
 
 // ✨ Props Interface
+type ImageMode = "none" | "auto";
 interface CardPreviewSmallProps {
   imageSrc?: string;
   youtubeId?: string;
@@ -15,6 +12,7 @@ interface CardPreviewSmallProps {
   description?: string;
   progress?: number;
   onClick?: () => void;
+  imageMode?: ImageMode; // default: "none"
 
   // Custom ClassNames
   className?: string;
@@ -25,6 +23,8 @@ interface CardPreviewSmallProps {
   classNameProgressWrapper?: string;
   classNameProgressBar?: string;
   classNameProgressText?: string;
+  /** chip/badge below the title (e.g., difficulty) */
+  badge?: ReactNode;
 }
 
 const CardPreviewSmall: React.FC<CardPreviewSmallProps> = ({
@@ -34,6 +34,7 @@ const CardPreviewSmall: React.FC<CardPreviewSmallProps> = ({
   description,
   progress = 0,
   onClick,
+  imageMode = "none",
   className,
   classNameTitle,
   classNameDescription,
@@ -42,110 +43,94 @@ const CardPreviewSmall: React.FC<CardPreviewSmallProps> = ({
   classNameProgressWrapper,
   classNameProgressBar,
   classNameProgressText,
+  badge,
 }) => {
   const displayImage = youtubeId
     ? `https://img.youtube.com/vi/${youtubeId}/hqdefault.jpg`
     : imageSrc;
+  const showImage = imageMode !== "none" && !!displayImage;
 
-  // Determine module status based on progress
-  const getModuleStatus = () => {
-    if (progress >= 100) return "completed";
-    if (progress > 0) return "in-progress";
-    return "not-started";
-  };
-
-  const status = getModuleStatus();
-
-  const getStatusIcon = () => {
-    switch (status) {
-      case "completed":
-        return <IoCheckmarkCircleOutline className="w-5 h-5 text-green-600" />;
-      case "in-progress":
-        return <IoTimeOutline className="w-5 h-5 text-dsp-orange" />;
-      default:
-        return <IoPlayCircleOutline className="w-5 h-5 text-gray-500" />;
-    }
-  };
-
-  const getProgressBarColor = () => {
-    switch (status) {
-      case "completed":
-        return "bg-green-500";
-      case "in-progress":
-        return "bg-dsp-orange";
-      default:
-        return "bg-gray-400";
-    }
-  };
+  const status =
+      progress >= 100 ? "completed" : progress > 0 ? "in-progress" : "not-started";
+  const statusText =
+      status === "completed" ? "Abgeschlossen" :
+          status === "in-progress" ? "In Bearbeitung" : "Nicht begonnen";
+  const statusColor =
+      status === "completed" ? "text-green-600" :
+          status === "in-progress" ? "text-dsp-orange" : "text-gray-500";
 
   return (
     <motion.div
       className={clsx(
-        // Base card styling - professional SaaS look
-        "relative group cursor-pointer isolate",
-        "bg-white",
-        "border border-gray-200/60 hover:border-dsp-orange/30",
+        "group relative isolate cursor-pointer",
         "rounded-xl overflow-hidden h-40 flex flex-col",
-        "shadow-sm hover:shadow-md",
-        "transition-all duration-200 ease-in-out",
-        "hover:-translate-y-1 hover:z-10",
+        "border border-gray-200/50 backdrop-blur-sm",
+        "bg-gradient-to-br from-white via-white/98 to-white/95",
+        "transition-all duration-500 hover:border-dsp-orange/30 hover:shadow-[0_12px_30px_-10px_rgba(0,0,0,0.25)]",
         className,
       )}
       onClick={onClick}
       whileHover={{ y: -2 }}
       transition={{ duration: 0.15 }}
     >
-      {/* Professional Image Container */}
-      {displayImage && (
+        {/* Optional image header (disabled by default via imageMode="none") */}
+        {showImage && (
         <div
           className={clsx(
-            "relative w-full h-24 overflow-hidden flex-shrink-0",
-            "bg-gradient-to-br from-gray-100 to-gray-200",
+              "relative w-full h-24 overflow-hidden flex-shrink-0",
+              "bg-gradient-to-br from-gray-100 to-gray-200",
             classNameImage,
           )}
         >
           <img
             src={displayImage}
             alt={title}
-            className="absolute inset-0 w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+            className="absolute inset-0 w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
             loading="lazy"
+            decoding="async"
           />
+            {/* white overlay gradient for text readability */}
+            <div className="absolute inset-0 bg-gradient-to-t from-white via-white/60 to-transparent" />
 
-          {/* Professional overlay gradient */}
-          <div className="absolute inset-0 bg-gradient-to-t from-black/20 via-transparent to-transparent" />
-
-          {/* Video play indicator */}
-          {youtubeId && (
-            <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-              <div className="bg-white/90 backdrop-blur-sm rounded-full p-3 shadow-lg">
-                <IoPlayCircleOutline className="w-8 h-8 text-dsp-orange" />
-              </div>
+            {/* center play button on hover */}
+            <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                <div className="h-10 w-10 rounded-full bg-white/90 backdrop-blur-sm grid place-items-center shadow">
+                    <IoPlay className="h-5 w-5 text-dsp-orange" />
+                </div>
             </div>
-          )}
-
-          {/* Status badge */}
-          <div className="absolute top-3 right-3">
-            <div className="bg-white/90 backdrop-blur-sm rounded-full p-2 shadow-sm">
-              {getStatusIcon()}
-            </div>
-          </div>
         </div>
       )}
+        {/* Hover gradient + glow */}
+        <div className="absolute inset-0 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity duration-500 bg-gradient-to-br from-dsp-orange/5 via-transparent to-emerald-400/5" />
+        <div className="absolute -inset-0.5 rounded-xl -z-10 pointer-events-none opacity-0 group-hover:opacity-100 blur-xl transition-all duration-500 bg-gradient-to-br from-dsp-orange/20 to-emerald-400/20" />
 
-      {/* Professional Content Area */}
-      <div className={clsx("p-4 flex-1 flex flex-col", classNameContentWrapper)}>
-        {/* Title Section */}
-         <div className="mb-3">
+
+      {/* Content */}
+        <div className={clsx("relative p-4 flex-1 flex flex-col", classNameContentWrapper)}>
+            {/* Header row: title + play */}
+            <div className="flex items-start justify-between gap-3 mb-2">
           <h3
             className={clsx(
               "font-semibold text-gray-900 text-base leading-tight",
-              "group-hover:text-dsp-orange transition-colors duration-200",
+              "group-hover:text-dsp-orange transition-colors duration-300",
               "line-clamp-2",
               classNameTitle,
             )}
+            title={title}
           >
             {title}
           </h3>
+                <button
+                    className="shrink-0 h-10 w-10 rounded-full bg-gray-100 hover:bg-dsp-orange hover:text-white transition-all duration-300 grid place-items-center shadow-sm"
+                    aria-label="Starten"
+                    type="button"
+                >
+                    <IoPlay className="h-5 w-5" />
+                </button>
+
+            </div>
+            {badge && <div className="mt-1">{badge}</div>}
+
 
           {description && (
             <p
@@ -157,68 +142,61 @@ const CardPreviewSmall: React.FC<CardPreviewSmallProps> = ({
               {description}
             </p>
           )}
-        </div>
 
-        {/* Professional Progress Section */}
-        <div className={clsx("space-y-2", classNameProgressWrapper)}>
-          {/* Progress header */}
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-2">
-              {getStatusIcon()}
-              <span className="text-xs font-medium text-gray-700">
-                {status === "completed"
-                  ? "Abgeschlossen"
-                  : status === "in-progress"
-                    ? "In Bearbeitung"
-                    : "Nicht begonnen"}
-              </span>
-            </div>
-            <span
-              className={clsx(
-                "text-xs font-semibold",
-                status === "completed"
-                  ? "text-green-600"
-                  : status === "in-progress"
-                    ? "text-dsp-orange"
-                    : "text-gray-500",
-                classNameProgressText,
-              )}
-            >
-              {progress}%
-            </span>
-          </div>
+            {/* Status + progress */}
+            <div className={clsx("mt-auto space-y-2", classNameProgressWrapper)}>
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                        <span
+                            className={clsx(
+                                "relative inline-flex h-3 w-3 rounded-full",
+                                status === "completed"
+                                    ? "bg-green-600"
+                                    : status === "in-progress"
+                                        ? "bg-dsp-orange"
+                                        : "bg-gray-400",
+                                )}
+                        >
+                            {status === "in-progress" && (
+                                <span className="absolute inset-0 rounded-full animate-ping opacity-75 bg-dsp-orange" />
+                            )}
+                        </span>
+                        <span className={clsx("text-xs font-medium", statusColor)}>
+                            {statusText}
+                        </span>
+                    </div>
+                    <span
+                        className={clsx(
+                            "text-xs font-semibold",
+                            statusColor,
+                            "bg-gray-100 px-2 py-0.5 rounded-md",
+                            classNameProgressText,
+                            )}
+                    >
+                        {Math.round(progress)}%
+                    </span>
+                </div>
 
-          {/* Professional progress bar */}
-          <div className="relative">
-            <div className="w-full bg-gray-200 rounded-full h-2 overflow-hidden">
-              <motion.div
-                className={clsx(
-                  "h-2 rounded-full transition-all duration-300",
-                  getProgressBarColor(),
-                  classNameProgressBar,
-                )}
-                initial={{ width: 0 }}
-                animate={{ width: `${progress}%` }}
-                transition={{ duration: 0.6, ease: "easeOut" }}
-              />
-            </div>
-
-            {/* Progress glow effect */}
-            {progress > 0 && (
-              <div
-                className={clsx(
-                  "absolute top-0 left-0 h-2 rounded-full opacity-50 blur-sm",
-                  getProgressBarColor(),
-                )}
-                style={{ width: `${Math.min(progress, 100)}%` }}
-              />
-            )}
-          </div>
+          {/* Gradient progress bar with shine */}
+                <div className="relative">
+                    <div className="w-full bg-gray-200 rounded-full h-2.5 overflow-hidden shadow-inner">
+                        <motion.div
+                            className={clsx(
+                                "h-full rounded-full transition-all duration-700 ease-out relative overflow-hidden",
+                                "bg-gradient-to-r from-dsp-orange via-orange-300 to-emerald-400",
+                                classNameProgressBar,
+                                )}
+                            initial={{ width: 0 }}
+                            animate={{ width: `${Math.min(Math.max(progress, 0), 100)}%` }}
+                        >
+                            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/40 to-transparent animate-pulse" />
+                        </motion.div>
+                    </div>
+                </div>
         </div>
       </div>
 
-      {/* Subtle hover glow */}
-      <div className="absolute inset-0 rounded-xl bg-gradient-to-br from-dsp-orange/5 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none" />
+      {/* (Glow handled above with two layers) */}
     </motion.div>
   );
 };

--- a/frontend/src/components/cards/card_preview_small.tsx
+++ b/frontend/src/components/cards/card_preview_small.tsx
@@ -51,13 +51,23 @@ const CardPreviewSmall: React.FC<CardPreviewSmallProps> = ({
   const showImage = imageMode !== "none" && !!displayImage;
 
   const status =
-      progress >= 100 ? "completed" : progress > 0 ? "in-progress" : "not-started";
+    progress >= 100
+      ? "completed"
+      : progress > 0
+        ? "in-progress"
+        : "not-started";
   const statusText =
-      status === "completed" ? "Abgeschlossen" :
-          status === "in-progress" ? "In Bearbeitung" : "Nicht begonnen";
+    status === "completed"
+      ? "Abgeschlossen"
+      : status === "in-progress"
+        ? "In Bearbeitung"
+        : "Nicht begonnen";
   const statusColor =
-      status === "completed" ? "text-green-600" :
-          status === "in-progress" ? "text-dsp-orange" : "text-gray-500";
+    status === "completed"
+      ? "text-green-600"
+      : status === "in-progress"
+        ? "text-dsp-orange"
+        : "text-gray-500";
 
   return (
     <motion.div
@@ -73,12 +83,12 @@ const CardPreviewSmall: React.FC<CardPreviewSmallProps> = ({
       whileHover={{ y: -2 }}
       transition={{ duration: 0.15 }}
     >
-        {/* Optional image header (disabled by default via imageMode="none") */}
-        {showImage && (
+      {/* Optional image header (disabled by default via imageMode="none") */}
+      {showImage && (
         <div
           className={clsx(
-              "relative w-full h-24 overflow-hidden flex-shrink-0",
-              "bg-gradient-to-br from-gray-100 to-gray-200",
+            "relative w-full h-24 overflow-hidden flex-shrink-0",
+            "bg-gradient-to-br from-gray-100 to-gray-200",
             classNameImage,
           )}
         >
@@ -89,110 +99,112 @@ const CardPreviewSmall: React.FC<CardPreviewSmallProps> = ({
             loading="lazy"
             decoding="async"
           />
-            {/* white overlay gradient for text readability */}
-            <div className="absolute inset-0 bg-gradient-to-t from-white via-white/60 to-transparent" />
+          {/* white overlay gradient for text readability */}
+          <div className="absolute inset-0 bg-gradient-to-t from-white via-white/60 to-transparent" />
 
-            {/* center play button on hover */}
-            <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                <div className="h-10 w-10 rounded-full bg-white/90 backdrop-blur-sm grid place-items-center shadow">
-                    <IoPlay className="h-5 w-5 text-dsp-orange" />
-                </div>
+          {/* center play button on hover */}
+          <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+            <div className="h-10 w-10 rounded-full bg-white/90 backdrop-blur-sm grid place-items-center shadow">
+              <IoPlay className="h-5 w-5 text-dsp-orange" />
             </div>
+          </div>
         </div>
       )}
-        {/* Hover gradient + glow */}
-        <div className="absolute inset-0 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity duration-500 bg-gradient-to-br from-dsp-orange/5 via-transparent to-emerald-400/5" />
-        <div className="absolute -inset-0.5 rounded-xl -z-10 pointer-events-none opacity-0 group-hover:opacity-100 blur-xl transition-all duration-500 bg-gradient-to-br from-dsp-orange/20 to-emerald-400/20" />
-
+      {/* Hover gradient + glow */}
+      <div className="absolute inset-0 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity duration-500 bg-gradient-to-br from-dsp-orange/5 via-transparent to-emerald-400/5" />
+      <div className="absolute -inset-0.5 rounded-xl -z-10 pointer-events-none opacity-0 group-hover:opacity-100 blur-xl transition-all duration-500 bg-gradient-to-br from-dsp-orange/20 to-emerald-400/20" />
 
       {/* Content */}
-        <div className={clsx("relative p-4 flex-1 flex flex-col", classNameContentWrapper)}>
-            {/* Header row: title + play */}
-            <div className="flex items-start justify-between gap-3 mb-2">
+      <div
+        className={clsx(
+          "relative p-4 flex-1 flex flex-col",
+          classNameContentWrapper,
+        )}
+      >
+        {/* Header row: title + play */}
+        <div className="flex items-start justify-between gap-3 mb-2">
           <h3
             className={clsx(
-                "ds-title leading-tight",
-                "group-hover:text-dsp-orange transition-colors duration-300",
-                "line-clamp-2",
-                classNameTitle,
-                )}
+              "ds-title leading-tight",
+              "group-hover:text-dsp-orange transition-colors duration-300",
+              "line-clamp-2",
+              classNameTitle,
+            )}
             title={title}
           >
             {title}
           </h3>
-                <button
-                    className="shrink-0 h-10 w-10 rounded-full bg-gray-100 hover:bg-dsp-orange hover:text-white transition-all duration-300 grid place-items-center shadow-sm"
-                    aria-label="Starten"
-                    type="button"
-                >
-                    <IoPlay className="h-5 w-5" />
-                </button>
+          <button
+            className="shrink-0 h-10 w-10 rounded-full bg-gray-100 hover:bg-dsp-orange hover:text-white transition-all duration-300 grid place-items-center shadow-sm"
+            aria-label="Starten"
+            type="button"
+          >
+            <IoPlay className="h-5 w-5" />
+          </button>
+        </div>
+        {badge && <div className="mt-1">{badge}</div>}
 
+        {description && (
+          <p
+            className={clsx(
+              "text-sm text-gray-600 mt-2 line-clamp-2",
+              classNameDescription,
+            )}
+          >
+            {description}
+          </p>
+        )}
+
+        {/* Status + progress */}
+        <div className={clsx("mt-auto space-y-2", classNameProgressWrapper)}>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span
+                className={clsx(
+                  "relative inline-flex h-3 w-3 rounded-full",
+                  status === "completed"
+                    ? "bg-green-600"
+                    : status === "in-progress"
+                      ? "bg-dsp-orange"
+                      : "bg-gray-400",
+                )}
+              >
+                {status === "in-progress" && (
+                  <span className="absolute inset-0 rounded-full animate-ping opacity-75 bg-dsp-orange" />
+                )}
+              </span>
+              <span className={clsx("text-xs font-medium", statusColor)}>
+                {statusText}
+              </span>
             </div>
-            {badge && <div className="mt-1">{badge}</div>}
-
-
-          {description && (
-            <p
+            <span
               className={clsx(
-                "text-sm text-gray-600 mt-2 line-clamp-2",
-                classNameDescription,
+                "text-xs font-semibold",
+                statusColor,
+                "bg-gray-100 px-2 py-0.5 rounded-md",
+                classNameProgressText,
               )}
             >
-              {description}
-            </p>
-          )}
-
-            {/* Status + progress */}
-            <div className={clsx("mt-auto space-y-2", classNameProgressWrapper)}>
-                <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                        <span
-                            className={clsx(
-                                "relative inline-flex h-3 w-3 rounded-full",
-                                status === "completed"
-                                    ? "bg-green-600"
-                                    : status === "in-progress"
-                                        ? "bg-dsp-orange"
-                                        : "bg-gray-400",
-                                )}
-                        >
-                            {status === "in-progress" && (
-                                <span className="absolute inset-0 rounded-full animate-ping opacity-75 bg-dsp-orange" />
-                            )}
-                        </span>
-                        <span className={clsx("text-xs font-medium", statusColor)}>
-                            {statusText}
-                        </span>
-                    </div>
-                    <span
-                        className={clsx(
-                            "text-xs font-semibold",
-                            statusColor,
-                            "bg-gray-100 px-2 py-0.5 rounded-md",
-                            classNameProgressText,
-                            )}
-                    >
-                        {Math.round(progress)}%
-                    </span>
-                </div>
+              {Math.round(progress)}%
+            </span>
+          </div>
 
           {/* Gradient progress bar with shine */}
-                <div className="relative">
-                    <div className="w-full bg-gray-200 rounded-full h-2.5 overflow-hidden shadow-inner">
-                        <motion.div
-                            className={clsx(
-                                "h-full rounded-full transition-all duration-700 ease-out relative overflow-hidden",
-                                "bg-gradient-to-r from-dsp-orange via-orange-300 to-emerald-400",
-                                classNameProgressBar,
-                                )}
-                            initial={{ width: 0 }}
-                            animate={{ width: `${Math.min(Math.max(progress, 0), 100)}%` }}
-                        >
-                            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/40 to-transparent animate-pulse" />
-                        </motion.div>
-                    </div>
-                </div>
+          <div className="relative">
+            <div className="w-full bg-gray-200 rounded-full h-2.5 overflow-hidden shadow-inner">
+              <motion.div
+                className={clsx(
+                  "h-full rounded-full transition-all duration-700 ease-out relative overflow-hidden",
+                  "bg-gradient-to-r from-dsp-orange via-orange-300 to-emerald-400",
+                  classNameProgressBar,
+                )}
+                initial={{ width: 0 }}
+                animate={{ width: `${Math.min(Math.max(progress, 0), 100)}%` }}
+              >
+                <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/40 to-transparent animate-pulse" />
+              </motion.div>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/frontend/src/components/cards/card_preview_small.tsx
+++ b/frontend/src/components/cards/card_preview_small.tsx
@@ -111,11 +111,11 @@ const CardPreviewSmall: React.FC<CardPreviewSmallProps> = ({
             <div className="flex items-start justify-between gap-3 mb-2">
           <h3
             className={clsx(
-              "font-semibold text-gray-900 text-base leading-tight",
-              "group-hover:text-dsp-orange transition-colors duration-300",
-              "line-clamp-2",
-              classNameTitle,
-            )}
+                "ds-title leading-tight",
+                "group-hover:text-dsp-orange transition-colors duration-300",
+                "line-clamp-2",
+                classNameTitle,
+                )}
             title={title}
           >
             {title}

--- a/frontend/src/components/layouts/footer.tsx
+++ b/frontend/src/components/layouts/footer.tsx
@@ -3,9 +3,9 @@ import { Link } from "react-router-dom";
 function FooterNavigation() {
   return (
     <footer
-      className="p-6 text-center text-sm text-gray-500 bg-dsp-white
-        flex w-full flex-wrap flex-row items-center justify-between "
+        className="p-6 text-center text-sm text-gray-500 bg-dsp-white flex w-full flex-wrap flex-row items-center justify-between"
     >
+
       © {new Date().getFullYear()} DataSmart Learning
       <ul className="flex flex-wrap items-center gap-x-12">
         <li>

--- a/frontend/src/components/layouts/footer.tsx
+++ b/frontend/src/components/layouts/footer.tsx
@@ -2,10 +2,7 @@ import { Link } from "react-router-dom";
 
 function FooterNavigation() {
   return (
-    <footer
-        className="p-6 text-center text-sm text-gray-500 bg-dsp-white flex w-full flex-wrap flex-row items-center justify-between"
-    >
-
+    <footer className="p-6 text-center text-sm text-gray-500 bg-dsp-white flex w-full flex-wrap flex-row items-center justify-between">
       © {new Date().getFullYear()} DataSmart Learning
       <ul className="flex flex-wrap items-center gap-x-12">
         <li>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -37,8 +37,16 @@ h6 {
   --color-dsp-orange_medium: #ffb697;
   --color-dsp-orange_light: #fedac7;
   --color-dsp-white: #ffffff;
+  --color-dsp-brown: #3a2a20; /* warm, readable heading color */
 
   --color-dsp-orange-gradient: #fa8c45;
+}
+
+/* Reusable title style for cards */
+@layer utilities {
+  .ds-title {
+    @apply text-[1.25rem] md:text-[1.35rem] font-semibold tracking-tight text-dsp-brown;
+  }
 }
 
 /* Chrome, Safari und Edge */

--- a/frontend/src/pages/modules.tsx
+++ b/frontend/src/pages/modules.tsx
@@ -427,14 +427,11 @@ function Modules() {
                             title={module.title}
                             youtubeId={getFirstYoutubeId(module)}
                             progress={roundedProgressPercent}
+                            badge={difficultyTagElement}
+                            imageMode="none"
                             className="w-full h-full border-0 bg-transparent hover:bg-transparent"
                             classNameTitle="text-left text-xl group-hover:text-dsp-orange transition-colors duration-200"
                           />
-                          {module.tasks && module.tasks.length > 0 && (
-                            <div className="absolute top-4 right-4 z-10">
-                              {difficultyTagElement}
-                            </div>
-                          )}
 
                           {/* Enhanced hover overlay */}
                           <div className="absolute inset-0 bg-gradient-to-t from-dsp-orange/5 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none"></div>

--- a/frontend/src/pages/modules.tsx
+++ b/frontend/src/pages/modules.tsx
@@ -422,7 +422,9 @@ function Modules() {
                         to={`/modules/${module.id}`}
                         className={clsx("block relative group h-full")}
                       >
-                        <div className="relative overflow-hidden rounded-xl h-full">  {/* keep simple wrapper only */}
+                        <div className="relative overflow-hidden rounded-xl h-full">
+                          {" "}
+                          {/* keep simple wrapper only */}
                           <CardPreviewSmall
                             title={module.title}
                             youtubeId={getFirstYoutubeId(module)}
@@ -432,7 +434,6 @@ function Modules() {
                             className="w-full h-full border-0 bg-transparent hover:bg-transparent"
                             classNameTitle="text-left text-xl group-hover:text-dsp-orange transition-colors duration-200"
                           />
-
                           {/* Enhanced hover overlay */}
                           <div className="absolute inset-0 bg-gradient-to-t from-dsp-orange/5 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none"></div>
                         </div>

--- a/frontend/src/pages/modules.tsx
+++ b/frontend/src/pages/modules.tsx
@@ -396,7 +396,7 @@ function Modules() {
             {viewMode === "standard" ? (
               <div
                 className={clsx(
-                  "grid gap-6 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5",
+                  "grid gap-6 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 items-stretch content-start",
                 )}
               >
                 {sortedAndFilteredModules.length > 0 ? (
@@ -420,9 +420,9 @@ function Modules() {
                       <Link
                         key={module.id}
                         to={`/modules/${module.id}`}
-                        className={clsx("block relative group")}
+                        className={clsx("block relative group h-full")}
                       >
-                        <div className="relative overflow-hidden rounded-xl border border-white/40 hover:border-dsp-orange/30 shadow-sm hover:shadow-md transition-all duration-200 hover:scale-[1.02] bg-white/60 backdrop-blur-sm hover:bg-white/80">
+                        <div className="relative overflow-hidden rounded-xl h-full">  {/* keep simple wrapper only */}
                           <CardPreviewSmall
                             title={module.title}
                             youtubeId={getFirstYoutubeId(module)}

--- a/frontend/tests/components/cards/card_modules_small.test.tsx
+++ b/frontend/tests/components/cards/card_modules_small.test.tsx
@@ -18,7 +18,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import CardModulesSmall from "../../../src/components/cards/card_modules_small.tsx";
 
-describe("CardModulesSmall", () => {
+describe("CardModulesSmall (new design)", () => {
   test("renders title, difficultyTag, derived status and progress", () => {
     render(
       <CardModulesSmall
@@ -34,6 +34,9 @@ describe("CardModulesSmall", () => {
     // status is derived from progress (65 -> "In Bearbeitung")
     expect(screen.getByText("In Bearbeitung")).toBeInTheDocument();
     expect(screen.getByText("65%")).toBeInTheDocument();
+
+    // Play button is present in header
+    expect(screen.getByRole("button", { name: /starten/i })).toBeInTheDocument();
   });
 
   test("click triggers onClick", async () => {
@@ -51,75 +54,46 @@ describe("CardModulesSmall", () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
-  // verify icon + colors based on derived status (from progress)
-  test("applies correct icon + colors for each derived status", () => {
-    const cases: Array<{
-      progress: number;
-      expectedText: "Nicht begonnen" | "In Bearbeitung" | "Abgeschlossen";
-      expectIconBoxHas: string; // bg-* class on the icon container
-      expectSvgHas: string; // text-* class on the <svg> icon
-      expectStatusTextHas: string; // text-* class on the status text span
-      expectBarHas: string; // bg-* class on the progress bar
-    }> = [
-      {
-        progress: 0,
-        expectedText: "Nicht begonnen",
-        expectIconBoxHas: "bg-gray-200",
-        expectSvgHas: "text-gray-600",
-        expectStatusTextHas: "text-gray-600",
-        expectBarHas: "bg-gray-300",
-      },
-      {
-        progress: 40,
-        expectedText: "In Bearbeitung",
-        expectIconBoxHas: "bg-dsp-orange",
-        expectSvgHas: "text-white",
-        expectStatusTextHas: "text-dsp-orange",
-        expectBarHas: "bg-dsp-orange",
-      },
-      {
-        progress: 100,
-        expectedText: "Abgeschlossen",
-        expectIconBoxHas: "bg-green-500",
-        expectSvgHas: "text-white",
-        expectStatusTextHas: "text-green-600",
-        expectBarHas: "bg-green-500",
-      },
-    ];
+  // verify status styles and gradient progress bar (new design)
+  test("applies correct status styles and renders gradient progress bar", () => {
+      const cases: Array<{
+        progress: number;
+        expectedText: "Nicht begonnen" | "In Bearbeitung" | "Abgeschlossen";
+        expectStatusTextHas: string; // text-* class on status text
+        expectDotBgHas: string;      // bg-* class on status dot
+        expectedPercent: string;
+      }> = [
+        { progress: 0, expectedText: "Nicht begonnen",  expectStatusTextHas: "text-gray-600",  expectDotBgHas: "bg-gray-400",  expectedPercent: "0%" },
+        { progress: 40, expectedText: "In Bearbeitung", expectStatusTextHas: "text-dsp-orange", expectDotBgHas: "bg-dsp-orange", expectedPercent: "40%" },
+        { progress: 100, expectedText: "Abgeschlossen", expectStatusTextHas: "text-green-600", expectDotBgHas: "bg-green-600", expectedPercent: "100%" },
+      ];
 
-    for (const c of cases) {
-      const { container, unmount } = render(
-        <CardModulesSmall
-          title="Probe"
-          progress={c.progress}
-          difficultyTag={<span />}
-        />,
-      );
+      for (const c of cases) {
+        const { container, unmount } = render(
+          <CardModulesSmall title="Probe" progress={c.progress} difficultyTag={<span />} />,
+        );
 
-      // status text element (derived)
-      const statusEl = screen.getByText(c.expectedText);
-      expect(statusEl.className).toContain(c.expectStatusTextHas);
+        // status text + color
+        const statusEl = screen.getByText(c.expectedText);
+        expect(statusEl).toBeInTheDocument();
+        expect(statusEl.className).toContain(c.expectStatusTextHas);
 
-      // icon box = the small square with width/height 10
-      const iconBox = container.querySelector(
-        "div.w-10.h-10.rounded-xl",
-      ) as HTMLDivElement;
-      expect(iconBox).toBeTruthy();
-      expect(iconBox!.className).toContain(c.expectIconBoxHas);
+        // percent badge
+        expect(screen.getByText(c.expectedPercent)).toBeInTheDocument();
 
-      // inside icon box there is an <svg> icon with a text-* color class
-      const iconSvg = iconBox!.querySelector("svg") as SVGElement;
-      expect(iconSvg).toBeTruthy();
-      expect(iconSvg.getAttribute("class") || "").toContain(c.expectSvgHas);
+        // status dot element
+        const dot = container.querySelector(
+          "span.inline-flex.h-3.w-3.rounded-full",
+        ) as HTMLSpanElement;
+        expect(dot).toBeTruthy();
+        expect(dot.className).toContain(c.expectDotBgHas);
 
-      // progress bar div (the inner moving bar)
-      const progressBar = container.querySelector(
-        'div[class*="h-1.5"][class*="rounded-full"][class*="transition-all"]',
-      ) as HTMLDivElement;
-      expect(progressBar).toBeTruthy();
-      expect(progressBar!.className).toContain(c.expectBarHas);
+        // gradient progress bar (new design)
+        const gradientBar = container.querySelector("div.bg-gradient-to-r") as HTMLDivElement;
+        expect(gradientBar).toBeTruthy();
 
-      unmount();
-    }
-  });
+        unmount();
+      }
+    });
+
 });

--- a/frontend/tests/components/cards/card_modules_small.test.tsx
+++ b/frontend/tests/components/cards/card_modules_small.test.tsx
@@ -36,7 +36,9 @@ describe("CardModulesSmall (new design)", () => {
     expect(screen.getByText("65%")).toBeInTheDocument();
 
     // Play button is present in header
-    expect(screen.getByRole("button", { name: /starten/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /starten/i }),
+    ).toBeInTheDocument();
   });
 
   test("click triggers onClick", async () => {
@@ -56,44 +58,67 @@ describe("CardModulesSmall (new design)", () => {
 
   // verify status styles and gradient progress bar (new design)
   test("applies correct status styles and renders gradient progress bar", () => {
-      const cases: Array<{
-        progress: number;
-        expectedText: "Nicht begonnen" | "In Bearbeitung" | "Abgeschlossen";
-        expectStatusTextHas: string; // text-* class on status text
-        expectDotBgHas: string;      // bg-* class on status dot
-        expectedPercent: string;
-      }> = [
-        { progress: 0, expectedText: "Nicht begonnen",  expectStatusTextHas: "text-gray-600",  expectDotBgHas: "bg-gray-400",  expectedPercent: "0%" },
-        { progress: 40, expectedText: "In Bearbeitung", expectStatusTextHas: "text-dsp-orange", expectDotBgHas: "bg-dsp-orange", expectedPercent: "40%" },
-        { progress: 100, expectedText: "Abgeschlossen", expectStatusTextHas: "text-green-600", expectDotBgHas: "bg-green-600", expectedPercent: "100%" },
-      ];
+    const cases: Array<{
+      progress: number;
+      expectedText: "Nicht begonnen" | "In Bearbeitung" | "Abgeschlossen";
+      expectStatusTextHas: string; // text-* class on status text
+      expectDotBgHas: string; // bg-* class on status dot
+      expectedPercent: string;
+    }> = [
+      {
+        progress: 0,
+        expectedText: "Nicht begonnen",
+        expectStatusTextHas: "text-gray-600",
+        expectDotBgHas: "bg-gray-400",
+        expectedPercent: "0%",
+      },
+      {
+        progress: 40,
+        expectedText: "In Bearbeitung",
+        expectStatusTextHas: "text-dsp-orange",
+        expectDotBgHas: "bg-dsp-orange",
+        expectedPercent: "40%",
+      },
+      {
+        progress: 100,
+        expectedText: "Abgeschlossen",
+        expectStatusTextHas: "text-green-600",
+        expectDotBgHas: "bg-green-600",
+        expectedPercent: "100%",
+      },
+    ];
 
-      for (const c of cases) {
-        const { container, unmount } = render(
-          <CardModulesSmall title="Probe" progress={c.progress} difficultyTag={<span />} />,
-        );
+    for (const c of cases) {
+      const { container, unmount } = render(
+        <CardModulesSmall
+          title="Probe"
+          progress={c.progress}
+          difficultyTag={<span />}
+        />,
+      );
 
-        // status text + color
-        const statusEl = screen.getByText(c.expectedText);
-        expect(statusEl).toBeInTheDocument();
-        expect(statusEl.className).toContain(c.expectStatusTextHas);
+      // status text + color
+      const statusEl = screen.getByText(c.expectedText);
+      expect(statusEl).toBeInTheDocument();
+      expect(statusEl.className).toContain(c.expectStatusTextHas);
 
-        // percent badge
-        expect(screen.getByText(c.expectedPercent)).toBeInTheDocument();
+      // percent badge
+      expect(screen.getByText(c.expectedPercent)).toBeInTheDocument();
 
-        // status dot element
-        const dot = container.querySelector(
-          "span.inline-flex.h-3.w-3.rounded-full",
-        ) as HTMLSpanElement;
-        expect(dot).toBeTruthy();
-        expect(dot.className).toContain(c.expectDotBgHas);
+      // status dot element
+      const dot = container.querySelector(
+        "span.inline-flex.h-3.w-3.rounded-full",
+      ) as HTMLSpanElement;
+      expect(dot).toBeTruthy();
+      expect(dot.className).toContain(c.expectDotBgHas);
 
-        // gradient progress bar (new design)
-        const gradientBar = container.querySelector("div.bg-gradient-to-r") as HTMLDivElement;
-        expect(gradientBar).toBeTruthy();
+      // gradient progress bar (new design)
+      const gradientBar = container.querySelector(
+        "div.bg-gradient-to-r",
+      ) as HTMLDivElement;
+      expect(gradientBar).toBeTruthy();
 
-        unmount();
-      }
-    });
-
+      unmount();
+    }
+  });
 });

--- a/frontend/tests/components/cards/card_preview_small.test.tsx
+++ b/frontend/tests/components/cards/card_preview_small.test.tsx
@@ -31,7 +31,14 @@ describe("CardPreviewSmall", () => {
   });
 
   test("uses YouTube thumbnail when youtubeId is provided", () => {
-    render(<CardPreviewSmall title="Video" youtubeId="abc123" progress={0} imageMode="auto" />);
+    render(
+      <CardPreviewSmall
+        title="Video"
+        youtubeId="abc123"
+        progress={0}
+        imageMode="auto"
+      />,
+    );
     const img = screen.getByAltText("Video") as HTMLImageElement;
     expect(img.src).toContain(
       "https://img.youtube.com/vi/abc123/hqdefault.jpg",
@@ -39,64 +46,69 @@ describe("CardPreviewSmall", () => {
   });
 
   test("shows correct status text + colors and gradient progress bar", () => {
-      const { container, rerender } = render(<CardPreviewSmall title="X" progress={0} />);
+    const { container, rerender } = render(
+      <CardPreviewSmall title="X" progress={0} />,
+    );
 
-      const assertCurrent = (expected: {
-        text: string;
-        progress: number;
-        statusClass: string;  // color class on status text
-        percentClass: string; // color class on % span
-        dotClass: string;     // bg-* class on status dot
-      }) => {
-        // status text + its dynamic color
-        const statusEl = screen.getByText(expected.text);
-        expect(statusEl).toBeInTheDocument();
-        expect(statusEl.className).toContain(expected.statusClass);
+    const assertCurrent = (expected: {
+      text: string;
+      progress: number;
+      statusClass: string; // color class on status text
+      percentClass: string; // color class on % span
+      dotClass: string; // bg-* class on status dot
+    }) => {
+      // status text + its dynamic color
+      const statusEl = screen.getByText(expected.text);
+      expect(statusEl).toBeInTheDocument();
+      expect(statusEl.className).toContain(expected.statusClass);
 
-        // percentage badge + its color
-        const percentEl = screen.getByText(`${expected.progress}%`);
-        expect(percentEl.className).toContain(expected.percentClass);
+      // percentage badge + its color
+      const percentEl = screen.getByText(`${expected.progress}%`);
+      expect(percentEl.className).toContain(expected.percentClass);
 
-        // colored status dot
-        const dot = container.querySelector("span.inline-flex.h-3.w-3.rounded-full") as HTMLSpanElement;
-        expect(dot).toBeTruthy();
-        expect(dot.className).toContain(expected.dotClass);
+      // colored status dot
+      const dot = container.querySelector(
+        "span.inline-flex.h-3.w-3.rounded-full",
+      ) as HTMLSpanElement;
+      expect(dot).toBeTruthy();
+      expect(dot.className).toContain(expected.dotClass);
 
-        // gradient progress bar exists
-        const gradientBar = container.querySelector("div.bg-gradient-to-r") as HTMLDivElement;
-        expect(gradientBar).toBeTruthy();
-      };
+      // gradient progress bar exists
+      const gradientBar = container.querySelector(
+        "div.bg-gradient-to-r",
+      ) as HTMLDivElement;
+      expect(gradientBar).toBeTruthy();
+    };
 
-      // 0% -> Nicht begonnen
-      assertCurrent({
-        text: "Nicht begonnen",
-        progress: 0,
-        statusClass: "text-gray-500",
-        percentClass: "text-gray-500",
-        dotClass: "bg-gray-400",
-      });
-
-      // 1–99% -> In Bearbeitung
-      rerender(<CardPreviewSmall title="X" progress={40} />);
-      assertCurrent({
-        text: "In Bearbeitung",
-        progress: 40,
-        statusClass: "text-dsp-orange",
-        percentClass: "text-dsp-orange",
-        dotClass: "bg-dsp-orange",
-      });
-
-      // 100% -> Abgeschlossen
-      rerender(<CardPreviewSmall title="X" progress={100} />);
-      assertCurrent({
-        text: "Abgeschlossen",
-        progress: 100,
-        statusClass: "text-green-600",
-        percentClass: "text-green-600",
-        dotClass: "bg-green-600",
-      });
+    // 0% -> Nicht begonnen
+    assertCurrent({
+      text: "Nicht begonnen",
+      progress: 0,
+      statusClass: "text-gray-500",
+      percentClass: "text-gray-500",
+      dotClass: "bg-gray-400",
     });
 
+    // 1–99% -> In Bearbeitung
+    rerender(<CardPreviewSmall title="X" progress={40} />);
+    assertCurrent({
+      text: "In Bearbeitung",
+      progress: 40,
+      statusClass: "text-dsp-orange",
+      percentClass: "text-dsp-orange",
+      dotClass: "bg-dsp-orange",
+    });
+
+    // 100% -> Abgeschlossen
+    rerender(<CardPreviewSmall title="X" progress={100} />);
+    assertCurrent({
+      text: "Abgeschlossen",
+      progress: 100,
+      statusClass: "text-green-600",
+      percentClass: "text-green-600",
+      dotClass: "bg-green-600",
+    });
+  });
 
   test("calls onClick when clicked", async () => {
     const user = userEvent.setup();

--- a/frontend/tests/components/cards/card_preview_small.test.tsx
+++ b/frontend/tests/components/cards/card_preview_small.test.tsx
@@ -31,68 +31,72 @@ describe("CardPreviewSmall", () => {
   });
 
   test("uses YouTube thumbnail when youtubeId is provided", () => {
-    render(<CardPreviewSmall title="Video" youtubeId="abc123" progress={0} />);
+    render(<CardPreviewSmall title="Video" youtubeId="abc123" progress={0} imageMode="auto" />);
     const img = screen.getByAltText("Video") as HTMLImageElement;
     expect(img.src).toContain(
       "https://img.youtube.com/vi/abc123/hqdefault.jpg",
     );
   });
 
-  test("shows correct status text based on progress (and verifies icon + percentage color)", () => {
-    const { container, rerender } = render(
-      <CardPreviewSmall title="X" progress={0} />,
-    );
+  test("shows correct status text + colors and gradient progress bar", () => {
+      const { container, rerender } = render(<CardPreviewSmall title="X" progress={0} />);
 
-    // We verify:
-    //  - status text (always visible, label is always gray-700 in component)
-    //  - SVG icon color (varies with status)
-    //  - percentage text color (varies with status)
-    const assertCurrent = (expected: {
-      text: string; // status text
-      progress: number; // current progress (to find the % element)
-      svgClass: string; // color class on the <svg> icon
-      percentClass: string; // color class on the {progress}% span
-    }) => {
-      // status label text (no dynamic color assertion here — it's always gray-700)
-      expect(screen.getByText(expected.text)).toBeInTheDocument();
+      const assertCurrent = (expected: {
+        text: string;
+        progress: number;
+        statusClass: string;  // color class on status text
+        percentClass: string; // color class on % span
+        dotClass: string;     // bg-* class on status dot
+      }) => {
+        // status text + its dynamic color
+        const statusEl = screen.getByText(expected.text);
+        expect(statusEl).toBeInTheDocument();
+        expect(statusEl.className).toContain(expected.statusClass);
 
-      // icon color
-      const svg = container.querySelector(
-        `svg[class*="${expected.svgClass}"]`,
-      ) as SVGElement | null;
-      expect(svg).toBeTruthy();
+        // percentage badge + its color
+        const percentEl = screen.getByText(`${expected.progress}%`);
+        expect(percentEl.className).toContain(expected.percentClass);
 
-      // percentage color
-      const percentEl = screen.getByText(`${expected.progress}%`);
-      expect(percentEl.className).toContain(expected.percentClass);
-    };
+        // colored status dot
+        const dot = container.querySelector("span.inline-flex.h-3.w-3.rounded-full") as HTMLSpanElement;
+        expect(dot).toBeTruthy();
+        expect(dot.className).toContain(expected.dotClass);
 
-    // 0% -> Nicht begonnen
-    assertCurrent({
-      text: "Nicht begonnen",
-      progress: 0,
-      svgClass: "text-gray-500",
-      percentClass: "text-gray-500",
+        // gradient progress bar exists
+        const gradientBar = container.querySelector("div.bg-gradient-to-r") as HTMLDivElement;
+        expect(gradientBar).toBeTruthy();
+      };
+
+      // 0% -> Nicht begonnen
+      assertCurrent({
+        text: "Nicht begonnen",
+        progress: 0,
+        statusClass: "text-gray-500",
+        percentClass: "text-gray-500",
+        dotClass: "bg-gray-400",
+      });
+
+      // 1–99% -> In Bearbeitung
+      rerender(<CardPreviewSmall title="X" progress={40} />);
+      assertCurrent({
+        text: "In Bearbeitung",
+        progress: 40,
+        statusClass: "text-dsp-orange",
+        percentClass: "text-dsp-orange",
+        dotClass: "bg-dsp-orange",
+      });
+
+      // 100% -> Abgeschlossen
+      rerender(<CardPreviewSmall title="X" progress={100} />);
+      assertCurrent({
+        text: "Abgeschlossen",
+        progress: 100,
+        statusClass: "text-green-600",
+        percentClass: "text-green-600",
+        dotClass: "bg-green-600",
+      });
     });
 
-    // 1–99% -> In Bearbeitung
-    rerender(<CardPreviewSmall title="X" progress={40} />);
-    assertCurrent({
-      text: "In Bearbeitung",
-      progress: 40,
-      svgClass: "text-dsp-orange",
-      percentClass: "text-dsp-orange",
-    });
-
-    // 100% -> Abgeschlossen
-    rerender(<CardPreviewSmall title="X" progress={100} />);
-    assertCurrent({
-      text: "Abgeschlossen",
-      progress: 100,
-      svgClass: "text-green-600",
-      percentClass: "text-green-600",
-    });
-  });
 
   test("calls onClick when clicked", async () => {
     const user = userEvent.setup();


### PR DESCRIPTION
This PR introduces the new card design to the modules grid and tidies up UI issues. Module card now have a consistent fixed height ( **h-40** ), titles are clamped to two lines with a eliipsis, and hover behavior is clean with no "bleeding" cards underneath. Typography has been refined via reusable ds-title utility. Both **CardPreviewSmall** and **CardModulesSmall** adopt the updated look: header with title + play button, colored status dot (with ping for in-progress), percentage badge, and a gradient progress bar. The difficulty badge is rendered inline under the title via a badge prop to avoid overlapping the play button. Images are optional default is image-less via **imageMode="none"**, with YouTube thumbnails still supported when needed. In modules.tsx the grid integration is streamlined **(items-stretch**), the old extra hover overlay is removed, and the new props are wired up. Tests were updated accordingly: we now assert status text color, the status dot, and the gradient progress bar (replacing icon color checks), plus click/render assertions were adjusted.