### PR TITLE
Fix/ccs-125-enter-confirm

### DIFF
--- a/frontend/src/components/ui_elements/bookmarks/BookmarkPanel.tsx
+++ b/frontend/src/components/ui_elements/bookmarks/BookmarkPanel.tsx
@@ -45,7 +45,7 @@ const BookmarkPanel: React.FC<BookmarkPanelProps> = ({
       <div className="flex items-center justify-between border-b border-dsp-orange_medium bg-dsp-orange px-2 py-1">
         <div className="text-xs font-semibold text-white">Lesezeichen</div>
         <div className="flex items-center gap-1">
-          <button
+          <button type="button"
             onClick={onToggleSelecting}
             className={[
               "rounded px-2 py-1 text-xs",
@@ -63,7 +63,7 @@ const BookmarkPanel: React.FC<BookmarkPanelProps> = ({
           >
             Setzen
           </button>
-          <button
+          <button type="button"
             onClick={onToggleNotes}
             className={[
               "rounded px-2 py-1 text-xs",
@@ -77,7 +77,7 @@ const BookmarkPanel: React.FC<BookmarkPanelProps> = ({
           >
             Notizen
           </button>
-          <button
+          <button type="button"
             onClick={onClearAll}
             className="rounded px-2 py-1 text-xs text-white hover:bg-white/10"
             aria-label="Alle Lesezeichen löschen"
@@ -85,7 +85,7 @@ const BookmarkPanel: React.FC<BookmarkPanelProps> = ({
           >
             Leeren
           </button>
-          <button
+          <button type="button"
             onClick={onClose}
             className="rounded px-2 py-1 text-xs text-white hover:bg-white/10"
             aria-label="Schließen"
@@ -115,7 +115,7 @@ const BookmarkPanel: React.FC<BookmarkPanelProps> = ({
                     placeholder={`Lesezeichen ${i + 1}`}
                     aria-label="Lesezeichen umbenennen"
                   />
-                  <button
+                  <button type="button"
                     onClick={(e) => {
                       e.stopPropagation();
                       onSaveEdit();
@@ -126,7 +126,7 @@ const BookmarkPanel: React.FC<BookmarkPanelProps> = ({
                   >
                     Speichern
                   </button>
-                  <button
+                  <button type="button"
                     onClick={(e) => {
                       e.stopPropagation();
                       onCancelEdit();
@@ -140,7 +140,7 @@ const BookmarkPanel: React.FC<BookmarkPanelProps> = ({
                 </>
               ) : (
                 <>
-                  <button
+                  <button type="button"
                     onClick={() => onJump(b.y, b.path)}
                     className="flex-1 rounded-md px-2 py-1 text-left text-sm text-gray-800 hover:bg-amber-50 cursor-pointer"
                     title={b.label ?? `Position ${b.y}px`}
@@ -148,7 +148,7 @@ const BookmarkPanel: React.FC<BookmarkPanelProps> = ({
                   >
                     {b.label?.trim() ? b.label : `Lesezeichen ${i + 1}`}
                   </button>
-                  <button
+                  <button type="button"
                     onClick={(e) => {
                       e.stopPropagation();
                       onStartEdit(b.id, b.label);
@@ -159,7 +159,7 @@ const BookmarkPanel: React.FC<BookmarkPanelProps> = ({
                   >
                     ✎
                   </button>
-                  <button
+                  <button type="button"
                     onClick={(e) => {
                       e.stopPropagation();
                       onRemove(b.id);

--- a/frontend/src/components/ui_elements/bookmarks/BookmarkPanel.tsx
+++ b/frontend/src/components/ui_elements/bookmarks/BookmarkPanel.tsx
@@ -45,7 +45,8 @@ const BookmarkPanel: React.FC<BookmarkPanelProps> = ({
       <div className="flex items-center justify-between border-b border-dsp-orange_medium bg-dsp-orange px-2 py-1">
         <div className="text-xs font-semibold text-white">Lesezeichen</div>
         <div className="flex items-center gap-1">
-          <button type="button"
+          <button
+            type="button"
             onClick={onToggleSelecting}
             className={[
               "rounded px-2 py-1 text-xs",
@@ -63,7 +64,8 @@ const BookmarkPanel: React.FC<BookmarkPanelProps> = ({
           >
             Setzen
           </button>
-          <button type="button"
+          <button
+            type="button"
             onClick={onToggleNotes}
             className={[
               "rounded px-2 py-1 text-xs",
@@ -77,7 +79,8 @@ const BookmarkPanel: React.FC<BookmarkPanelProps> = ({
           >
             Notizen
           </button>
-          <button type="button"
+          <button
+            type="button"
             onClick={onClearAll}
             className="rounded px-2 py-1 text-xs text-white hover:bg-white/10"
             aria-label="Alle Lesezeichen löschen"
@@ -85,7 +88,8 @@ const BookmarkPanel: React.FC<BookmarkPanelProps> = ({
           >
             Leeren
           </button>
-          <button type="button"
+          <button
+            type="button"
             onClick={onClose}
             className="rounded px-2 py-1 text-xs text-white hover:bg-white/10"
             aria-label="Schließen"
@@ -115,7 +119,8 @@ const BookmarkPanel: React.FC<BookmarkPanelProps> = ({
                     placeholder={`Lesezeichen ${i + 1}`}
                     aria-label="Lesezeichen umbenennen"
                   />
-                  <button type="button"
+                  <button
+                    type="button"
                     onClick={(e) => {
                       e.stopPropagation();
                       onSaveEdit();
@@ -126,7 +131,8 @@ const BookmarkPanel: React.FC<BookmarkPanelProps> = ({
                   >
                     Speichern
                   </button>
-                  <button type="button"
+                  <button
+                    type="button"
                     onClick={(e) => {
                       e.stopPropagation();
                       onCancelEdit();
@@ -140,7 +146,8 @@ const BookmarkPanel: React.FC<BookmarkPanelProps> = ({
                 </>
               ) : (
                 <>
-                  <button type="button"
+                  <button
+                    type="button"
                     onClick={() => onJump(b.y, b.path)}
                     className="flex-1 rounded-md px-2 py-1 text-left text-sm text-gray-800 hover:bg-amber-50 cursor-pointer"
                     title={b.label ?? `Position ${b.y}px`}
@@ -148,7 +155,8 @@ const BookmarkPanel: React.FC<BookmarkPanelProps> = ({
                   >
                     {b.label?.trim() ? b.label : `Lesezeichen ${i + 1}`}
                   </button>
-                  <button type="button"
+                  <button
+                    type="button"
                     onClick={(e) => {
                       e.stopPropagation();
                       onStartEdit(b.id, b.label);
@@ -159,7 +167,8 @@ const BookmarkPanel: React.FC<BookmarkPanelProps> = ({
                   >
                     ✎
                   </button>
-                  <button type="button"
+                  <button
+                    type="button"
                     onClick={(e) => {
                       e.stopPropagation();
                       onRemove(b.id);

--- a/frontend/src/components/ui_elements/buttons/button_primary.tsx
+++ b/frontend/src/components/ui_elements/buttons/button_primary.tsx
@@ -28,7 +28,7 @@ import { motion } from "framer-motion";
 interface ButtonPrimaryProps {
   title: string;
   icon?: React.ReactNode;
-  onClick: () => void;
+  onClick?: () => void;
   classNameButton?: string;
   classNameIcon?: string;
   disabled?: boolean;

--- a/frontend/src/components/ui_elements/buttons/button_secondary.tsx
+++ b/frontend/src/components/ui_elements/buttons/button_secondary.tsx
@@ -9,6 +9,7 @@ interface ButtonSecondaryProps extends HoverHandlers {
   classNameIcon?: string;
   disabled?: boolean;
   iconPosition?: "left" | "right";
+  type?: "button" | "submit" | "reset";
 }
 
 const ButtonSecondary: React.FC<ButtonSecondaryProps> = ({
@@ -21,6 +22,7 @@ const ButtonSecondary: React.FC<ButtonSecondaryProps> = ({
   iconPosition = "right",
   onHoverStart,
   onHoverEnd,
+  type,
 }) => {
   const buttonVariants = {
     initial: { scale: 1 },
@@ -38,6 +40,7 @@ const ButtonSecondary: React.FC<ButtonSecondaryProps> = ({
 
   return (
     <motion.button
+      type={type ?? "button"}
       onClick={onClick}
       disabled={disabled}
       onHoverStart={onHoverStart}

--- a/frontend/src/components/ui_elements/forms/create_user_form.tsx
+++ b/frontend/src/components/ui_elements/forms/create_user_form.tsx
@@ -275,7 +275,7 @@ const CreateUserForm: React.FC<CreateUserFormProps> = ({
         </div>
       )}
 
-      <form className="space-y-6">
+      <form onSubmit={handleSubmit} className="space-y-6">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div>
             <label
@@ -395,7 +395,8 @@ const CreateUserForm: React.FC<CreateUserFormProps> = ({
           )}
           <ButtonPrimary
             title={loading ? "Wird erstellt..." : "Benutzer erstellen"}
-            onClick={() => handleSubmit()}
+            type="submit"
+            onClick={() => {}}
             disabled={loading}
           />
         </div>

--- a/frontend/src/pages/ExternalRegister.tsx
+++ b/frontend/src/pages/ExternalRegister.tsx
@@ -561,7 +561,6 @@ const ExternalRegister: React.FC = () => {
               title={loading ? "Registriere..." : "Registrieren"}
               disabled={loading || !isFormValid}
               classNameButton="w-full"
-              onClick={() => {}}
             />
           </div>
         </form>

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -423,16 +423,16 @@ const LoginPopup: React.FC<LoginPopupProps> = ({ onClose }) => {
                   ${isClosing ? "opacity-0 translate-y-4" : ""}`}
                 >
                   <ButtonPrimary
-                      type="submit"
-                      title={isLoading ? "Anmelden..." : "Anmelden"}
-                      classNameButton={`w-full py-3 shadow-lg shadow-dsp-orange/25 transform transition-all duration-200 ease-in-out
+                    type="submit"
+                    title={isLoading ? "Anmelden..." : "Anmelden"}
+                    classNameButton={`w-full py-3 shadow-lg shadow-dsp-orange/25 transform transition-all duration-200 ease-in-out
                       ${
                         isLoading
                           ? "opacity-70 cursor-not-allowed"
                           : "hover:scale-[1.02] hover:shadow-xl hover:shadow-dsp-orange/30"
                       }`}
-                      disabled={isLoading}
-                    />
+                    disabled={isLoading}
+                  />
                 </div>
               </form>
 

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -423,16 +423,16 @@ const LoginPopup: React.FC<LoginPopupProps> = ({ onClose }) => {
                   ${isClosing ? "opacity-0 translate-y-4" : ""}`}
                 >
                   <ButtonPrimary
-                    onClick={handleLoginSubmit}
-                    title={isLoading ? "Anmelden..." : "Anmelden"}
-                    classNameButton={`w-full py-3 shadow-lg shadow-dsp-orange/25 transform transition-all duration-200 ease-in-out
-                    ${
-                      isLoading
-                        ? "opacity-70 cursor-not-allowed"
-                        : "hover:scale-[1.02] hover:shadow-xl hover:shadow-dsp-orange/30"
-                    }`}
-                    disabled={isLoading}
-                  />
+                      type="submit"
+                      title={isLoading ? "Anmelden..." : "Anmelden"}
+                      classNameButton={`w-full py-3 shadow-lg shadow-dsp-orange/25 transform transition-all duration-200 ease-in-out
+                      ${
+                        isLoading
+                          ? "opacity-70 cursor-not-allowed"
+                          : "hover:scale-[1.02] hover:shadow-xl hover:shadow-dsp-orange/30"
+                      }`}
+                      disabled={isLoading}
+                    />
                 </div>
               </form>
 

--- a/frontend/src/pages/user_settings/account.tsx
+++ b/frontend/src/pages/user_settings/account.tsx
@@ -11,7 +11,6 @@ import { toast } from "sonner";
 import DspNotification from "../../components/toaster/notifications/DspNotification";
 // import api from "../../util/apis/api"; // Importiere die konfigurierte Axios-Instanz
 
-
 const Account: React.FC = () => {
   const [loadingPassword, setLoadingPassword] = useState(false);
   const [errorPassword, setErrorPassword] = useState<string | null>(null);
@@ -43,7 +42,7 @@ const Account: React.FC = () => {
   };
 
   const handlePasswordSubmit = async (e: React.FormEvent) => {
-     e.preventDefault();
+    e.preventDefault();
     // Validation
     if (
       !passwordData.current_password ||
@@ -140,8 +139,6 @@ const Account: React.FC = () => {
       />
     ));
   };
-
-
 
   return (
     <motion.div

--- a/frontend/src/pages/user_settings/account.tsx
+++ b/frontend/src/pages/user_settings/account.tsx
@@ -9,9 +9,8 @@ import {
 } from "react-icons/io5";
 import { toast } from "sonner";
 import DspNotification from "../../components/toaster/notifications/DspNotification";
-import api from "../../util/apis/api"; // Importiere die konfigurierte Axios-Instanz
+// import api from "../../util/apis/api"; // Importiere die konfigurierte Axios-Instanz
 
-interface ProfileApiResponse {}
 
 const Account: React.FC = () => {
   const [loadingPassword, setLoadingPassword] = useState(false);
@@ -43,7 +42,8 @@ const Account: React.FC = () => {
     return Math.random() > 0.3; // 70% success rate for demo
   };
 
-  const handlePasswordSubmit = async () => {
+  const handlePasswordSubmit = async (e: React.FormEvent) => {
+     e.preventDefault();
     // Validation
     if (
       !passwordData.current_password ||
@@ -141,10 +141,7 @@ const Account: React.FC = () => {
     ));
   };
 
-  const UserFetchData = async () => {
-    let response = await api.get<ProfileApiResponse>("/users/me/");
-    return response.data;
-  };
+
 
   return (
     <motion.div
@@ -175,7 +172,7 @@ const Account: React.FC = () => {
               </div>
             )}
 
-            <div className="space-y-3">
+            <form onSubmit={handlePasswordSubmit} className="space-y-3">
               <div>
                 <label
                   htmlFor="currentPassword"
@@ -238,15 +235,16 @@ const Account: React.FC = () => {
               </div>
               <div className="flex justify-end">
                 <ButtonPrimary
+                  type="submit"
                   title={
                     loadingPassword ? "Speichern..." : "Passwort speichern"
                   }
                   icon={<IoSaveOutline />}
-                  onClick={handlePasswordSubmit}
+                  onClick={() => {}}
                   disabled={loadingPassword}
                 />
               </div>
-            </div>
+            </form>
           </div>
 
           {/* Konto löschen */}

--- a/frontend/src/pages/user_settings/profile.tsx
+++ b/frontend/src/pages/user_settings/profile.tsx
@@ -216,7 +216,7 @@ const Profile: React.FC = () => {
               icon={<IoSaveOutline className="w-4 h-4" />}
               disabled={loadingProfile}
               classNameButton="w-full sm:w-auto"
-              type="submit"   // submit via form (enables Enter)
+              type="submit" // submit via form (enables Enter)
               onClick={() => {}} // no-op; submission handled by <form>
             />
           </motion.div>

--- a/frontend/src/pages/user_settings/profile.tsx
+++ b/frontend/src/pages/user_settings/profile.tsx
@@ -28,7 +28,8 @@ const Profile: React.FC = () => {
     return Math.random() > 0.2; // 80% success rate for demo
   };
 
-  const handleProfileSubmit = async () => {
+  const handleProfileSubmit = async (e?: React.FormEvent) => {
+    e?.preventDefault();
     setLoadingProfile(true);
     setErrorProfile(null);
     setSuccessProfile(false);
@@ -123,7 +124,7 @@ const Profile: React.FC = () => {
           </motion.div>
         )}
 
-        <div className="space-y-6">
+        <form onSubmit={handleProfileSubmit} className="space-y-6">
           {/* Form Fields */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <motion.div
@@ -208,16 +209,18 @@ const Profile: React.FC = () => {
                 });
               }}
               classNameButton="w-full sm:w-auto"
+              type="button"
             />
             <ButtonPrimary
               title={loadingProfile ? "Speichern..." : "Profil speichern"}
               icon={<IoSaveOutline className="w-4 h-4" />}
-              onClick={handleProfileSubmit}
               disabled={loadingProfile}
               classNameButton="w-full sm:w-auto"
+              type="submit"   // submit via form (enables Enter)
+              onClick={() => {}} // no-op; submission handled by <form>
             />
           </motion.div>
-        </div>
+        </form>
       </SubBackground>
     </motion.div>
   );


### PR DESCRIPTION
This branch makes the app’s forms behave like real forms so users can confirm actions with the Enter key. I refactored key flows to submit via **form onSubmit={...}** and converted primary actions to proper **type="submit"** buttons, removing ad-hoc **onClick** handlers that blocked keyboard submission. As part of that, **ButtonSecondary** now accepts an optional **type** prop; **Profile** and **Account** in user settings were rewired to submit through their forms; and **CreateUserForm** was updated to call its logic from **onSubmi**t and use a submit button. There are no visual changes—just better accessibility, consistency, and fewer double-submit edge cases. I verified Enter submission for each adjusted screen and confirmed existing click flows continue to work.