### PR TITLE
subscriptions vorerst ausgeblendet, bis wir externe user erlauben

### DIFF
--- a/frontend/src/components/common/AnimatedRoutes.tsx
+++ b/frontend/src/components/common/AnimatedRoutes.tsx
@@ -198,6 +198,7 @@ const AnimatedRoutes: React.FC<AnimatedRoutesProps> = ({ isAdmin }) => {
               </PageTransition>
             }
           />
+          {/* SUBSCRIPTIONS AUSGEBLENDET
           <Route
             path="/subscriptions"
             element={
@@ -206,6 +207,7 @@ const AnimatedRoutes: React.FC<AnimatedRoutesProps> = ({ isAdmin }) => {
               </PageTransition>
             }
           />
+          */}
 
           {/* Prüfungen und Zertifikate */}
           <Route

--- a/frontend/src/components/layouts/header.tsx
+++ b/frontend/src/components/layouts/header.tsx
@@ -23,6 +23,12 @@ const HeaderNavigation: React.FC<HeaderNavigationProps> = ({
   };
 
   const linksWithSubscriptions = useMemo(() => {
+
+    // SUBSCRIPTIONS AUSGEBLENDET
+    // Abonnements vorerst ausblenden, bis die E-Learning-
+    // Plattform auch von externen Usern verwendet wird
+    return links;
+
     const alreadyHas = links.some((l) => l.to === "/subscriptions");
     return alreadyHas ? links : [...links, subscriptionsLink];
   }, [links]);

--- a/frontend/src/components/layouts/header.tsx
+++ b/frontend/src/components/layouts/header.tsx
@@ -23,7 +23,6 @@ const HeaderNavigation: React.FC<HeaderNavigationProps> = ({
   };
 
   const linksWithSubscriptions = useMemo(() => {
-
     // SUBSCRIPTIONS AUSGEBLENDET
     // Abonnements vorerst ausblenden, bis die E-Learning-
     // Plattform auch von externen Usern verwendet wird

--- a/frontend/src/components/layouts/header.types.ts
+++ b/frontend/src/components/layouts/header.types.ts
@@ -68,7 +68,7 @@ export type HeaderNavigationProps = {
  */
 export const publicNavLinks: NavLink[] = [
   { title: "Startseite", to: "/" },
-  { title: "Preise", to: "/subscriptions" },
+  /*{ title: "Preise", to: "/subscriptions" }, SUBSCRIPTIONS AUSGEBLENDET*/
   {
     title: "Homepage",
     to: "https://datasmartpoint.com/?campaign=search&gad_source=1&gclid=Cj0KCQjw2N2_BhCAARIsAK4pEkWFhF857MNP-sEAtIJvfG32jDDe1wbcFucbaaWDH-N9DYaHlNN__X4aAoKqEALw_wcB",

--- a/frontend/tests/components/common/AnimatedRoutes.test.tsx
+++ b/frontend/tests/components/common/AnimatedRoutes.test.tsx
@@ -263,12 +263,13 @@ describe("AnimatedRoutes", () => {
     ).not.toBeInTheDocument();
   });
 
+  /*SUBSCRIPTIONS AUSGEBLENDET
   it("renders Subscription when signed in", async () => {
     signIn();
     renderRoute("/subscriptions");
     expect(await screen.findByText("Mocked Subscriptions")).toBeInTheDocument();
   });
-
+  */
   it("does not render Final Exam when signed out", async () => {
     signOut();
     renderRoute("/final-exam");

--- a/frontend/tests/components/common/AnimatedRoutes.test.tsx
+++ b/frontend/tests/components/common/AnimatedRoutes.test.tsx
@@ -263,13 +263,12 @@ describe("AnimatedRoutes", () => {
     ).not.toBeInTheDocument();
   });
 
-  /*SUBSCRIPTIONS AUSGEBLENDET
-  it("renders Subscription when signed in", async () => {
+  it.skip("renders Subscription when signed in", async () => {
     signIn();
     renderRoute("/subscriptions");
     expect(await screen.findByText("Mocked Subscriptions")).toBeInTheDocument();
   });
-  */
+
   it("does not render Final Exam when signed out", async () => {
     signOut();
     renderRoute("/final-exam");

--- a/frontend/tests/components/layouts/header.test.tsx
+++ b/frontend/tests/components/layouts/header.test.tsx
@@ -98,8 +98,8 @@ describe("HeaderNavigation", () => {
 
     expect(screen.getByText("Settings")).toBeInTheDocument();
   });
-  /* SUBSCRIPTIONS AUSGEBLENDET
-  it("automatically adds /subscriptions link if not present", () => {
+
+  it.skip("automatically adds /subscriptions link if not present", () => {
     renderWithAppProviders(
       <HeaderNavigation
         links={[{ title: "Dashboard", to: "/dashboard" }]}
@@ -115,7 +115,6 @@ describe("HeaderNavigation", () => {
       "/subscriptions",
     );
   });
-  */
 
   it("does not add /subscriptions link if not present and not authenticated", () => {
     renderWithAppProviders(

--- a/frontend/tests/components/layouts/header.test.tsx
+++ b/frontend/tests/components/layouts/header.test.tsx
@@ -98,7 +98,7 @@ describe("HeaderNavigation", () => {
 
     expect(screen.getByText("Settings")).toBeInTheDocument();
   });
-
+  /* SUBSCRIPTIONS AUSGEBLENDET
   it("automatically adds /subscriptions link if not present", () => {
     renderWithAppProviders(
       <HeaderNavigation
@@ -115,6 +115,7 @@ describe("HeaderNavigation", () => {
       "/subscriptions",
     );
   });
+  */
 
   it("does not add /subscriptions link if not present and not authenticated", () => {
     renderWithAppProviders(


### PR DESCRIPTION
Alle Buttons, Links, Routing und Tests für die Abonnements auskommentiert

Mit "SUBSCRIPTIONS AUSGEBLENDET" im Kommentar versehen, damit man sie wieder leicht findet.