### PR TITLE
Fix/ccs-36-make-header-responsive

### DIFF
--- a/frontend/src/components/layouts/header.tsx
+++ b/frontend/src/components/layouts/header.tsx
@@ -94,8 +94,11 @@ const HeaderNavigation: React.FC<HeaderNavigationProps> = ({
       >
         <div className="max-w-[95vw] mx-auto px-4 sm:px-6">
           <div className="flex items-center h-14">
-             {/* Left: Logo */}
-            <div className="flex items-center gap-3" data-testid="logo-container">
+            {/* Left: Logo */}
+            <div
+              className="flex items-center gap-3"
+              data-testid="logo-container"
+            >
               {logo && (
                 <Link to={"/dashboard"} aria-label={"Zum Dashboard"}>
                   <div className="h-8 flex items-center">
@@ -107,7 +110,6 @@ const HeaderNavigation: React.FC<HeaderNavigationProps> = ({
                   </div>
                 </Link>
               )}
-
             </div>
 
             {/* Center: Desktop Navigation */}
@@ -117,27 +119,27 @@ const HeaderNavigation: React.FC<HeaderNavigationProps> = ({
               </ul>
             </nav>
 
-             {/* Right: Actions (desktop) + Burger (mobile) */}
-              <div className="ml-auto flex items-center">
-                  {/* Desktop right content */}
-                  <div className="hidden md:flex items-center justify-end">
-                      <ul className="flex items-center gap-1">
-                          {renderRightContentItems(filteredRightContent)}
-                      </ul>
-                  </div>
-                  {/* Mobile burger aligned right */}
-                  <button
-                      onClick={() => setMobileOpen((prev) => !prev)}
-                      className="md:hidden ml-2 relative p-1.5 rounded-lg text-gray-700 hover:text-dsp-orange hover:bg-dsp-orange/5 transition-colors duration-200"
-                      aria-label="Toggle Navigation"
-                  >
-                      {mobileOpen ? (
-                          <IoMdClose className="w-5 h-5" />
-                      ) : (
-                          <IoMdMenu className="w-5 h-5" />
-                      )}
-                  </button>
+            {/* Right: Actions (desktop) + Burger (mobile) */}
+            <div className="ml-auto flex items-center">
+              {/* Desktop right content */}
+              <div className="hidden md:flex items-center justify-end">
+                <ul className="flex items-center gap-1">
+                  {renderRightContentItems(filteredRightContent)}
+                </ul>
               </div>
+              {/* Mobile burger aligned right */}
+              <button
+                onClick={() => setMobileOpen((prev) => !prev)}
+                className="md:hidden ml-2 relative p-1.5 rounded-lg text-gray-700 hover:text-dsp-orange hover:bg-dsp-orange/5 transition-colors duration-200"
+                aria-label="Toggle Navigation"
+              >
+                {mobileOpen ? (
+                  <IoMdClose className="w-5 h-5" />
+                ) : (
+                  <IoMdMenu className="w-5 h-5" />
+                )}
+              </button>
+            </div>
           </div>
         </div>
       </header>
@@ -163,9 +165,9 @@ const HeaderNavigation: React.FC<HeaderNavigationProps> = ({
                   {filteredLinks.map((link, index) => (
                     <li key={index}>
                       <LinkSidebar
-                          to={link.to}
-                          icon={link.icon}
-                          className="flex items-center w-full px-3 py-2 rounded-lg transition-colors duration-200"
+                        to={link.to}
+                        icon={link.icon}
+                        className="flex items-center w-full px-3 py-2 rounded-lg transition-colors duration-200"
                       >
                         {link.title}
                       </LinkSidebar>
@@ -185,9 +187,9 @@ const HeaderNavigation: React.FC<HeaderNavigationProps> = ({
                       <li key={index}>
                         {item.to ? (
                           <LinkSidebar
-                              to={item.to}
-                              icon={item.icon}
-                              className="flex items-center w-full px-3 py-2 rounded-lg transition-colors duration-200"
+                            to={item.to}
+                            icon={item.icon}
+                            className="flex items-center w-full px-3 py-2 rounded-lg transition-colors duration-200"
                           >
                             {item.title}
                           </LinkSidebar>

--- a/frontend/src/components/layouts/header.tsx
+++ b/frontend/src/components/layouts/header.tsx
@@ -41,7 +41,11 @@ const HeaderNavigation: React.FC<HeaderNavigationProps> = ({
     navLinks.map((link, index) => (
       <li key={index}>
         <LinkSidebar to={link.to} icon={link.icon}>
-          {showTitle ? link.title : null}
+          {showTitle ? (
+            <span className="max-w-[180px] lg:max-w-[220px] xl:max-w-[260px] truncate whitespace-nowrap align-middle">
+              {link.title}
+            </span>
+          ) : null}
         </LinkSidebar>
       </li>
     ));
@@ -51,17 +55,29 @@ const HeaderNavigation: React.FC<HeaderNavigationProps> = ({
       <li key={index}>
         {item.to ? (
           <LinkSidebar to={item.to} icon={item.icon}>
-            {showTitle ? item.title : null}
+            {showTitle ? (
+              <span className="max-w-[160px] lg:max-w-[200px] truncate whitespace-nowrap">
+                {item.title}
+              </span>
+            ) : null}
           </LinkSidebar>
         ) : (
           <button
             onClick={item.action}
-            className="flex items-center px-3 py-1.5 text-sm font-medium rounded-lg text-gray-700 hover:text-dsp-orange 
-                     hover:bg-dsp-orange/5 transition-colors duration-200 cursor-pointer"
+            className="flex items-center px-2.5 py-1 text-xs sm:text-sm md:px-3 md:py-1.5 md:text-sm font-medium rounded-lg
+            text-gray-700 hover:text-dsp-orange hover:bg-dsp-orange/5 transition-colors duration-200 cursor-pointer"
             aria-label={item.title}
           >
-            {item.icon && <span className="mr-2">{item.icon}</span>}
-            {showTitle && <span>{item.title}</span>}
+            {item.icon && (
+              <span className="mr-1.5 md:mr-2 [&>svg]:w-4 [&>svg]:h-4 md:[&>svg]:w-5 md:[&>svg]:h-5">
+                {item.icon}
+              </span>
+            )}
+            {showTitle && (
+              <span className="truncate max-w-[140px] sm:max-w-[170px] md:max-w-none">
+                {item.title}
+              </span>
+            )}
           </button>
         )}
       </li>
@@ -77,12 +93,9 @@ const HeaderNavigation: React.FC<HeaderNavigationProps> = ({
         )}
       >
         <div className="max-w-[95vw] mx-auto px-4 sm:px-6">
-          <div className="flex items-center justify-between h-14">
-            {/* Left Section: Logo & Mobile Menu */}
-            <div
-              className="flex items-center gap-3"
-              data-testid="logo-container"
-            >
+          <div className="flex items-center h-14">
+             {/* Left: Logo */}
+            <div className="flex items-center gap-3" data-testid="logo-container">
               {logo && (
                 <Link to={"/dashboard"} aria-label={"Zum Dashboard"}>
                   <div className="h-8 flex items-center">
@@ -95,19 +108,6 @@ const HeaderNavigation: React.FC<HeaderNavigationProps> = ({
                 </Link>
               )}
 
-              {/* Mobile Menu Button */}
-              <button
-                onClick={() => setMobileOpen((prev) => !prev)}
-                className="md:hidden relative p-1.5 rounded-lg text-gray-700 hover:text-dsp-orange 
-                         hover:bg-dsp-orange/5 transition-colors duration-200"
-                aria-label="Toggle Navigation"
-              >
-                {mobileOpen ? (
-                  <IoMdClose className="w-5 h-5" />
-                ) : (
-                  <IoMdMenu className="w-5 h-5" />
-                )}
-              </button>
             </div>
 
             {/* Center: Desktop Navigation */}
@@ -117,12 +117,27 @@ const HeaderNavigation: React.FC<HeaderNavigationProps> = ({
               </ul>
             </nav>
 
-            {/* Right Section */}
-            <div className="hidden md:flex items-center justify-end">
-              <ul className="flex items-center gap-1">
-                {renderRightContentItems(filteredRightContent)}
-              </ul>
-            </div>
+             {/* Right: Actions (desktop) + Burger (mobile) */}
+              <div className="ml-auto flex items-center">
+                  {/* Desktop right content */}
+                  <div className="hidden md:flex items-center justify-end">
+                      <ul className="flex items-center gap-1">
+                          {renderRightContentItems(filteredRightContent)}
+                      </ul>
+                  </div>
+                  {/* Mobile burger aligned right */}
+                  <button
+                      onClick={() => setMobileOpen((prev) => !prev)}
+                      className="md:hidden ml-2 relative p-1.5 rounded-lg text-gray-700 hover:text-dsp-orange hover:bg-dsp-orange/5 transition-colors duration-200"
+                      aria-label="Toggle Navigation"
+                  >
+                      {mobileOpen ? (
+                          <IoMdClose className="w-5 h-5" />
+                      ) : (
+                          <IoMdMenu className="w-5 h-5" />
+                      )}
+                  </button>
+              </div>
           </div>
         </div>
       </header>
@@ -148,10 +163,9 @@ const HeaderNavigation: React.FC<HeaderNavigationProps> = ({
                   {filteredLinks.map((link, index) => (
                     <li key={index}>
                       <LinkSidebar
-                        to={link.to}
-                        icon={link.icon}
-                        className="flex items-center w-full px-3 py-2 text-gray-700 hover:text-dsp-orange 
-                                 hover:bg-dsp-orange/5 rounded-lg transition-colors duration-200"
+                          to={link.to}
+                          icon={link.icon}
+                          className="flex items-center w-full px-3 py-2 rounded-lg transition-colors duration-200"
                       >
                         {link.title}
                       </LinkSidebar>
@@ -171,10 +185,9 @@ const HeaderNavigation: React.FC<HeaderNavigationProps> = ({
                       <li key={index}>
                         {item.to ? (
                           <LinkSidebar
-                            to={item.to}
-                            icon={item.icon}
-                            className="flex items-center w-full px-3 py-2 text-gray-700 hover:text-dsp-orange 
-                                     hover:bg-dsp-orange/5 rounded-lg transition-colors duration-200"
+                              to={item.to}
+                              icon={item.icon}
+                              className="flex items-center w-full px-3 py-2 rounded-lg transition-colors duration-200"
                           >
                             {item.title}
                           </LinkSidebar>

--- a/frontend/src/components/ui_elements/buttons/button_toggle_sidebar.tsx
+++ b/frontend/src/components/ui_elements/buttons/button_toggle_sidebar.tsx
@@ -30,14 +30,14 @@ const ButtonToggleSmall: React.FC<ButtonToggleSmallProps> = ({
           "hover:cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-dsp-orange/50 " +
           // keep rotation
           "rotate-180"
-            }
+        }
       >
         {icon && <span className={classNameIcon}>{icon}</span>}
-          {title && (
-              <span className="truncate whitespace-nowrap max-w-[120px] sm:max-w-[160px] md:max-w-none">
-                  {title}
-              </span>
-          )}
+        {title && (
+          <span className="truncate whitespace-nowrap max-w-[120px] sm:max-w-[160px] md:max-w-none">
+            {title}
+          </span>
+        )}
       </button>
     </div>
   );

--- a/frontend/src/components/ui_elements/buttons/button_toggle_sidebar.tsx
+++ b/frontend/src/components/ui_elements/buttons/button_toggle_sidebar.tsx
@@ -19,10 +19,25 @@ const ButtonToggleSmall: React.FC<ButtonToggleSmallProps> = ({
     <div className={classNameButton}>
       <button
         onClick={onClick}
-        className="flex items-center space-x-2 border rounded-lg bg-dsp-orange_light p-1 hover:cursor-pointer focus:outline-none rotate-180"
+        aria-label={title || "Toggle menu"}
+        className={
+          "flex items-center space-x-2 border rounded-lg bg-dsp-orange_light " +
+          // smaller on mobile, scale up on md+
+          "px-2 py-1 text-xs md:px-3 md:py-1.5 md:text-sm " +
+          // consistent icon sizing
+          "[&>span_svg]:w-4 [&>span_svg]:h-4 md:[&>span_svg]:w-5 md:[&>span_svg]:h-5 " +
+          // usability
+          "hover:cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-dsp-orange/50 " +
+          // keep rotation
+          "rotate-180"
+            }
       >
         {icon && <span className={classNameIcon}>{icon}</span>}
-        {title && <span className="text-sm md:text-base">{title}</span>}
+          {title && (
+              <span className="truncate whitespace-nowrap max-w-[120px] sm:max-w-[160px] md:max-w-none">
+                  {title}
+              </span>
+          )}
       </button>
     </div>
   );

--- a/frontend/src/components/ui_elements/links/link_sidebar.tsx
+++ b/frontend/src/components/ui_elements/links/link_sidebar.tsx
@@ -97,23 +97,23 @@ const LinkSidebar: React.FC<LinkSidebarProps> = ({
         )}
 
         {/* Text content (truncate on one line) */}
-          <motion.span
-              className="relative z-10 min-w-0 flex-1"
-              whileHover={{ x: 2 }}
-              transition={{ type: "spring", stiffness: 300, damping: 20 }}
+        <motion.span
+          className="relative z-10 min-w-0 flex-1"
+          whileHover={{ x: 2 }}
+          transition={{ type: "spring", stiffness: 300, damping: 20 }}
+        >
+          <span
+            className={clsx(
+              // prevent wrapping & show ellipsis when narrow
+              "block truncate whitespace-nowrap",
+              // responsive max widths to balance truncation vs. readability
+              "max-w-[140px] sm:max-w-[180px] md:max-w-[220px] lg:max-w-[260px]",
+            )}
+            title={typeof children === "string" ? children : undefined}
           >
-              <span
-                  className={clsx(
-                      // prevent wrapping & show ellipsis when narrow
-                      "block truncate whitespace-nowrap",
-                      // responsive max widths to balance truncation vs. readability
-                      "max-w-[140px] sm:max-w-[180px] md:max-w-[220px] lg:max-w-[260px]"
-                  )}
-                  title={typeof children === "string" ? children : undefined}
-              >
-                  {children}
-              </span>
-          </motion.span>
+            {children}
+          </span>
+        </motion.span>
 
         {/* Ripple effect on click */}
         <motion.div

--- a/frontend/src/components/ui_elements/links/link_sidebar.tsx
+++ b/frontend/src/components/ui_elements/links/link_sidebar.tsx
@@ -19,6 +19,7 @@ const LinkSidebar: React.FC<LinkSidebarProps> = ({
 }) => {
   const location = useLocation();
   const isActive = location.pathname === to;
+  const hasIcon = !!icon;
 
   // Determine what to preload based on route
   const handleMouseEnter = () => {
@@ -39,7 +40,16 @@ const LinkSidebar: React.FC<LinkSidebarProps> = ({
         to={to}
         onMouseEnter={handleMouseEnter}
         className={clsx(
-          "flex items-center gap-3 px-8 py-2.5 rounded-xl text-sm font-medium transition-all duration-200 cursor-pointer group relative overflow-hidden",
+          // flex row with min-w-0 so the text can truncate
+          // NOTE: When active AND no icon, add extra left padding to make room for the dot.
+          hasIcon
+            ? "flex items-center gap-3 px-3 sm:px-4 md:px-6 lg:px-8 py-2 sm:py-2.5 rounded-xl text-sm font-medium transition-all duration-200 cursor-pointer group relative overflow-hidden"
+            : clsx(
+                "flex items-center gap-3 py-2 sm:py-2.5 rounded-xl text-sm font-medium transition-all duration-200 cursor-pointer group relative overflow-hidden",
+                isActive
+                  ? "pl-8 sm:pl-9 md:pl-10 pr-3 sm:pr-4 md:pr-6 lg:pr-8"
+                  : "px-3 sm:px-4 md:px-6 lg:px-8",
+              ),
           {
             // Active state - enhanced with subtle animations
             "bg-gradient-to-r from-dsp-orange to-dsp-orange-gradient text-white shadow-sm shadow-dsp-orange/20":
@@ -53,9 +63,10 @@ const LinkSidebar: React.FC<LinkSidebarProps> = ({
         aria-current={isActive ? "page" : undefined}
       >
         {/* Active indicator dot */}
-        {isActive && (
+        {isActive && !hasIcon && (
           <motion.div
-            className="absolute left-4 top-1/2 -translate-y-1/2 w-2 h-2 bg-white rounded-full shadow-sm"
+            // Place the dot within the left padding area and keep it behind text.
+            className="absolute left-3 top-1/2 -translate-y-1/2 w-2 h-2 bg-white rounded-full shadow-sm z-0 pointer-events-none"
             animate={{ scale: [1, 1.2, 1], opacity: [0.8, 1, 0.8] }}
             transition={{ duration: 2, repeat: Infinity, ease: "easeInOut" }}
           />
@@ -74,7 +85,7 @@ const LinkSidebar: React.FC<LinkSidebarProps> = ({
         {/* Icon with enhanced animations */}
         {icon && (
           <motion.span
-            className={clsx("relative z-10", {
+            className={clsx("relative z-10 shrink-0", {
               "text-white": isActive,
               "text-gray-500 group-hover:text-dsp-orange": !isActive,
             })}
@@ -85,14 +96,24 @@ const LinkSidebar: React.FC<LinkSidebarProps> = ({
           </motion.span>
         )}
 
-        {/* Text content */}
-        <motion.span
-          className="relative z-10"
-          whileHover={{ x: 2 }}
-          transition={{ type: "spring", stiffness: 300, damping: 20 }}
-        >
-          {children}
-        </motion.span>
+        {/* Text content (truncate on one line) */}
+          <motion.span
+              className="relative z-10 min-w-0 flex-1"
+              whileHover={{ x: 2 }}
+              transition={{ type: "spring", stiffness: 300, damping: 20 }}
+          >
+              <span
+                  className={clsx(
+                      // prevent wrapping & show ellipsis when narrow
+                      "block truncate whitespace-nowrap",
+                      // responsive max widths to balance truncation vs. readability
+                      "max-w-[140px] sm:max-w-[180px] md:max-w-[220px] lg:max-w-[260px]"
+                  )}
+                  title={typeof children === "string" ? children : undefined}
+              >
+                  {children}
+              </span>
+          </motion.span>
 
         {/* Ripple effect on click */}
         <motion.div

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,9 +11,6 @@
   h3 {
     @apply text-2xl;
   }
-  h1 {
-    @apply text-xl;
-  }
 }
 
 body {
@@ -69,3 +66,17 @@ h6 {
 /* Regeln wurden in ComingSoonOverlaySmall.css verschoben */
 /* @keyframes spin-slow { ... } */
 /* .animate-spin-slow { ... } */
+
+/* --- Utilities for header truncation & mobile spacing --- */
+@layer utilities {
+  /* Ensure flex children can actually truncate when placed in a row */
+  .min-w-0 { min-width: 0; }
+
+  /* Convenience class if we ever want to apply one-line ellipsis via className */
+  .no-wrap-ellipsis { @apply truncate whitespace-nowrap; }
+
+  /* smaller buttons on very narrow screens without touching Tailwind config */
+  @media (max-width: 380px) {
+    .btn-xs { @apply px-2 py-1 text-xs; }
+  }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -70,13 +70,19 @@ h6 {
 /* --- Utilities for header truncation & mobile spacing --- */
 @layer utilities {
   /* Ensure flex children can actually truncate when placed in a row */
-  .min-w-0 { min-width: 0; }
+  .min-w-0 {
+    min-width: 0;
+  }
 
   /* Convenience class if we ever want to apply one-line ellipsis via className */
-  .no-wrap-ellipsis { @apply truncate whitespace-nowrap; }
+  .no-wrap-ellipsis {
+    @apply truncate whitespace-nowrap;
+  }
 
   /* smaller buttons on very narrow screens without touching Tailwind config */
   @media (max-width: 380px) {
-    .btn-xs { @apply px-2 py-1 text-xs; }
+    .btn-xs {
+      @apply px-2 py-1 text-xs;
+    }
   }
 }

--- a/frontend/tests/components/layouts/header.test.tsx
+++ b/frontend/tests/components/layouts/header.test.tsx
@@ -1,6 +1,7 @@
 import HeaderNavigation from "@/components/layouts/header";
 import { renderWithAppProviders } from "../../test-utils";
 import { fireEvent, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { server } from "../../testServer.ts";
 import { MemoryRouter } from "react-router-dom";
 
@@ -144,4 +145,67 @@ describe("HeaderNavigation", () => {
     expect(subscriptionLinks).toHaveLength(1);
     expect(subscriptionLinks[0]).toHaveAttribute("href", "/subscriptions");
   });
+
+  it("renders a mobile burger button with responsive classes and in the right container", () => {
+      renderWithAppProviders(
+          <HeaderNavigation links={[{ title: "Dashboard", to: "/dashboard" }]} />,
+          );
+
+      const burger = screen.getByLabelText(/toggle navigation/i);
+      expect(burger).toBeInTheDocument();
+
+      // burger is hidden on md+ (mobile-only)
+      expect(burger.className).toMatch(/md:hidden/);
+
+      // parent container aligns to right via ml-auto
+      const parent = burger.parentElement as HTMLElement | null;
+      expect(parent?.className).toMatch(/ml-auto/);
+  });
+
+  it("active mobile menu item keeps white text on hover (no parent hover override)", async () => {
+      // Make /dashboard the active route so the link is in 'active' state
+      render(
+          <MemoryRouter initialEntries={["/dashboard"]}>
+              <HeaderNavigation links={[{ title: "Dashboard", to: "/dashboard" }]} />
+          </MemoryRouter>
+      );
+
+      // open menu (userEvent wraps in act)
+      await userEvent.click(screen.getByLabelText(/toggle navigation/i));
+
+      // find the active link inside the mobile menu
+      const mobileMenu = screen.getByTestId("mobile-menu");
+      const activeLink = within(mobileMenu).getByRole("link", {
+          name: /dashboard/i,
+      }) as HTMLAnchorElement;
+
+      // Ensure it is marked as active and does NOT have hover text color class
+      expect(activeLink.getAttribute("aria-current")).toBe("page");
+      expect(activeLink.className).not.toMatch(/hover:text-[\w-]+/);
+  });
+
+
+  it("nav link labels use truncation classes to avoid wrapping", () => {
+      renderWithAppProviders(
+          <HeaderNavigation
+              links={[
+                  {
+                      title: "Ein sehr sehr langer Navigationspunkt der truncaten sollte",
+                      to: "/x",
+                  },
+              ]}
+          />,
+          );
+
+      const link = screen.getByRole("link", {
+          name: /ein sehr sehr langer navigationspunkt/i,
+      });
+
+      // In LinkSidebar the visible text sits in an inner <span> with 'truncate'
+      const truncatingSpan = link.querySelector("span.truncate");
+      expect(truncatingSpan).toBeTruthy();
+      expect(truncatingSpan?.className).toMatch(/whitespace-nowrap/);
+  });
+
+
 });

--- a/frontend/tests/components/layouts/header.test.tsx
+++ b/frontend/tests/components/layouts/header.test.tsx
@@ -147,65 +147,62 @@ describe("HeaderNavigation", () => {
   });
 
   it("renders a mobile burger button with responsive classes and in the right container", () => {
-      renderWithAppProviders(
-          <HeaderNavigation links={[{ title: "Dashboard", to: "/dashboard" }]} />,
-          );
+    renderWithAppProviders(
+      <HeaderNavigation links={[{ title: "Dashboard", to: "/dashboard" }]} />,
+    );
 
-      const burger = screen.getByLabelText(/toggle navigation/i);
-      expect(burger).toBeInTheDocument();
+    const burger = screen.getByLabelText(/toggle navigation/i);
+    expect(burger).toBeInTheDocument();
 
-      // burger is hidden on md+ (mobile-only)
-      expect(burger.className).toMatch(/md:hidden/);
+    // burger is hidden on md+ (mobile-only)
+    expect(burger.className).toMatch(/md:hidden/);
 
-      // parent container aligns to right via ml-auto
-      const parent = burger.parentElement as HTMLElement | null;
-      expect(parent?.className).toMatch(/ml-auto/);
+    // parent container aligns to right via ml-auto
+    const parent = burger.parentElement as HTMLElement | null;
+    expect(parent?.className).toMatch(/ml-auto/);
   });
 
   it("active mobile menu item keeps white text on hover (no parent hover override)", async () => {
-      // Make /dashboard the active route so the link is in 'active' state
-      render(
-          <MemoryRouter initialEntries={["/dashboard"]}>
-              <HeaderNavigation links={[{ title: "Dashboard", to: "/dashboard" }]} />
-          </MemoryRouter>
-      );
+    // Make /dashboard the active route so the link is in 'active' state
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <HeaderNavigation links={[{ title: "Dashboard", to: "/dashboard" }]} />
+      </MemoryRouter>,
+    );
 
-      // open menu (userEvent wraps in act)
-      await userEvent.click(screen.getByLabelText(/toggle navigation/i));
+    // open menu (userEvent wraps in act)
+    await userEvent.click(screen.getByLabelText(/toggle navigation/i));
 
-      // find the active link inside the mobile menu
-      const mobileMenu = screen.getByTestId("mobile-menu");
-      const activeLink = within(mobileMenu).getByRole("link", {
-          name: /dashboard/i,
-      }) as HTMLAnchorElement;
+    // find the active link inside the mobile menu
+    const mobileMenu = screen.getByTestId("mobile-menu");
+    const activeLink = within(mobileMenu).getByRole("link", {
+      name: /dashboard/i,
+    }) as HTMLAnchorElement;
 
-      // Ensure it is marked as active and does NOT have hover text color class
-      expect(activeLink.getAttribute("aria-current")).toBe("page");
-      expect(activeLink.className).not.toMatch(/hover:text-[\w-]+/);
+    // Ensure it is marked as active and does NOT have hover text color class
+    expect(activeLink.getAttribute("aria-current")).toBe("page");
+    expect(activeLink.className).not.toMatch(/hover:text-[\w-]+/);
   });
-
 
   it("nav link labels use truncation classes to avoid wrapping", () => {
-      renderWithAppProviders(
-          <HeaderNavigation
-              links={[
-                  {
-                      title: "Ein sehr sehr langer Navigationspunkt der truncaten sollte",
-                      to: "/x",
-                  },
-              ]}
-          />,
-          );
+    renderWithAppProviders(
+      <HeaderNavigation
+        links={[
+          {
+            title: "Ein sehr sehr langer Navigationspunkt der truncaten sollte",
+            to: "/x",
+          },
+        ]}
+      />,
+    );
 
-      const link = screen.getByRole("link", {
-          name: /ein sehr sehr langer navigationspunkt/i,
-      });
+    const link = screen.getByRole("link", {
+      name: /ein sehr sehr langer navigationspunkt/i,
+    });
 
-      // In LinkSidebar the visible text sits in an inner <span> with 'truncate'
-      const truncatingSpan = link.querySelector("span.truncate");
-      expect(truncatingSpan).toBeTruthy();
-      expect(truncatingSpan?.className).toMatch(/whitespace-nowrap/);
+    // In LinkSidebar the visible text sits in an inner <span> with 'truncate'
+    const truncatingSpan = link.querySelector("span.truncate");
+    expect(truncatingSpan).toBeTruthy();
+    expect(truncatingSpan?.className).toMatch(/whitespace-nowrap/);
   });
-
-
 });


### PR DESCRIPTION
This PR makes the header fully responsive. The burger menu now aligns to the right on small screens, titles stay on a single line with truncation, and header buttons scale down slightly for better usability on mobile. I also refined LinkSidebar so the active indicator dot no longer overlaps text and active items remain readable on hover. Tests were updated to cover the mobile toggle, truncation, and hover behavior. 